### PR TITLE
Implement item creation API

### DIFF
--- a/src/api/endpoints/item/requests.ts
+++ b/src/api/endpoints/item/requests.ts
@@ -1,5 +1,5 @@
 import {apiClient} from "@/api/axios";
-import {CustomizationOption, CustomizationRule, Item, PartialItem} from "@/types/item";
+import {CustomizationOption, CustomizationRule, Item, ItemCreate, PartialItem} from "@/types/item";
 
 
 const baseRoute = "/items"
@@ -7,6 +7,11 @@ const baseRoute = "/items"
 
 
 export const itemsApi = {
+
+    createItem: async (formData: FormData) => {
+        const response = await apiClient.post<Item>(`${baseRoute}/`, formData)
+        return response.data
+    },
 
     deleteItem: async (itemId: string) => {
         const response = await apiClient.delete(`${baseRoute}/${itemId}`)


### PR DESCRIPTION
## Summary
- add item API `createItem` function
- integrate `createItem` on create item page with `showPromiseToast`

## Testing
- `npm run lint` *(fails: module not found)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6849aa6067b88333bac8b22b1b0fe618