### PR TITLE
Implement recipes tab

### DIFF
--- a/src/types/stock.ts
+++ b/src/types/stock.ts
@@ -63,6 +63,8 @@ export type RecipeIngredient = {
 
 export type RecipeCreate = {
     dishName: string;
+    /** Associated menu item ID */
+    menuItemId: string;
     ingredients: Array<RecipeIngredient>;
     servings: number;
     cost: number;


### PR DESCRIPTION
## Summary
- extend Recipe types with menu item id
- load menu items for restaurant
- allow creating recipes linked to menu items
- add Recipes tab with listing and deletion

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68506b86b5e48333951d33071f46dd73