### PR TITLE
Remove email from team invitations

### DIFF
--- a/src/components/pages/dashboard-staff/invitations-table.tsx
+++ b/src/components/pages/dashboard-staff/invitations-table.tsx
@@ -8,7 +8,7 @@ export function InvitationsTable({ invitations }: { invitations: Invitation[] })
         <Table>
             <TableHeader>
                 <TableRow>
-                    <TableHead>Email</TableHead>
+                    <TableHead>Nome</TableHead>
                     <TableHead>Função</TableHead>
                     <TableHead>Enviado em</TableHead>
                 </TableRow>
@@ -16,7 +16,7 @@ export function InvitationsTable({ invitations }: { invitations: Invitation[] })
             <TableBody>
                 {invitations.map((invitation) => (
                     <TableRow key={invitation._id}>
-                        <TableCell>{invitation.email}</TableCell>
+                        <TableCell>{invitation.name}</TableCell>
                         <TableCell>{invitation.role}</TableCell>
                         <TableCell>{format(new Date(invitation.createdAt), "dd/MM/yyyy", { locale: ptBR })}</TableCell>
                     </TableRow>

--- a/src/context/dashboard-staff-context.tsx
+++ b/src/context/dashboard-staff-context.tsx
@@ -88,7 +88,6 @@ export function DashboardStaffProvider({ children }: { children: ReactNode }) {
 
     const [inviteForm, setInviteForm] = useState<InvitationCreate>({
         name: "",
-        email: "",
         role: "",
         managerId: user._id,
         restaurantId: restaurant._id

--- a/src/pages/dashboard/staff.tsx
+++ b/src/pages/dashboard/staff.tsx
@@ -199,7 +199,6 @@ function StaffContent() {
     const handleInviteMember = () => {
         const invitationData: InvitationCreate = {
             name: "", // Required by InvitationCreate type
-            email: inviteForm.email,
             role: inviteForm.role,
             managerId: user._id,
             restaurantId: restaurant._id
@@ -428,7 +427,7 @@ function StaffContent() {
                                         </DialogHeader>
 
                                         <div className="space-y-4">
-                                            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                                            <div className="grid grid-cols-1 gap-4">
                                                 <div className="flex flex-col space-y-2">
                                                     <Label htmlFor="name">Nome Completo</Label>
                                                     <Input
@@ -436,16 +435,6 @@ function StaffContent() {
                                                         value={inviteForm.name}
                                                         onChange={(e) => setInviteForm({ ...inviteForm, name: e.target.value })}
                                                         placeholder="Digite o nome completo"
-                                                    />
-                                                </div>
-                                                <div className="flex flex-col space-y-2">
-                                                    <Label htmlFor="email">Email</Label>
-                                                    <Input
-                                                        id="email"
-                                                        type="email"
-                                                        value={inviteForm.email}
-                                                        onChange={(e) => setInviteForm({ ...inviteForm, email: e.target.value })}
-                                                        placeholder="email@exemplo.com"
                                                     />
                                                 </div>
                                             </div>

--- a/src/types/invitation.ts
+++ b/src/types/invitation.ts
@@ -2,10 +2,9 @@
 
 export type InvitationCreate = {
     name: string
-    email: string,
-    role: string,
-    managerId: string,
-    restaurantId: string,
+    role: string
+    managerId: string
+    restaurantId: string
 }
 
 


### PR DESCRIPTION
## Summary
- drop email field from `InvitationCreate`
- update staff invitation form to no longer ask for email
- update invitation table to show name instead of email
- adjust context default invite form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68508852f04c833399f477725acf8ad4