### PR TITLE
Use order group endpoint

### DIFF
--- a/src/pages/dashboard/custom-order.tsx
+++ b/src/pages/dashboard/custom-order.tsx
@@ -20,6 +20,8 @@ import {useGetMenuItemsBySlug} from "@/api/endpoints/menu/hooks";
 import {useListRestaurantTables} from "@/api/endpoints/tables/hooks";
 import {useCart} from "@/hooks/use-cart";
 import {showErrorToast, showPromiseToast, showWarningToast} from "@/utils/notifications/toast";
+import {ordersApi} from "@/api/endpoints/orders/requests";
+import {sessionApi} from "@/api/endpoints/sessions/requests";
 
 
 export default function OrderCustomizationPage() {
@@ -291,7 +293,23 @@ export default function OrderCustomizationPage() {
             return
         }
 
-        const promise = new Promise<void>((resolve) => setTimeout(resolve, 1000))
+        const promise = sessionApi.getActiveSessionByTableNumber(selectedTable, restaurant._id)
+            .then((session) => {
+                const orders = cart.map((cartItem) => ({
+                    sessionId: session._id,
+                    itemId: cartItem.id,
+                    quantity: cartItem.quantity,
+                    additionalNote: cartItem.additionalNotes,
+                    customisations: cartItem.customisations,
+                    orderedItemName: cartItem.name,
+                    restaurantId: restaurant._id,
+                    unitPrice: cartItem.price,
+                    total: cartItem.price * cartItem.quantity,
+                    tableNumber: selectedTable,
+                }))
+
+                return ordersApi.addOrdersGroup(orders, session._id)
+            })
 
         showPromiseToast(promise, {
             loading: "Submitting order...",

--- a/src/pages/restaurant/cart.tsx
+++ b/src/pages/restaurant/cart.tsx
@@ -60,29 +60,28 @@ export function Cart() {
         const items = cart.map((item) => item)
 
         if (session && session?._id) {
+            const orders = items.map(item => ({
+                sessionId: session._id,
+                itemId: item.id,
+                quantity: item.quantity,
+                additionalNote: item.additionalNote,
+                customizations: [],
+                orderedItemName: item.name,
+                restaurantId: restaurant._id,
+                unitPrice: item.price,
+                total: item.price * item.quantity,
+                tableNumber: Number(tableNumber)
+            }))
 
-            // TODO: post the orders as a list
-            for (const item of items) {
-                ordersApi.addOrder({
-                    sessionId: session?._id,
-                    itemId: item.id,
-                    quantity: item.quantity,
-                    additionalNote: item.additionalNote,
-                    customizations: [],
-                    orderedItemName: item.name,
-                    restaurantId: restaurant._id,
-                    unitPrice: item.price,
-                    total: item.price * item.quantity,
-                    tableNumber: Number(tableNumber)
-                }, session._id).catch(() => {
-                    setOrderStatus("Error")
-                    setAlertMessage("Houve um erro com o seu pedido, um garçon irá confirmar o seu pedido em breve.")
-                }).then(() => {
-                    setOrderStatus("Success")
-                    setAlertMessage(`O seu pedido será levado á sua mesa em breve!`)
-                    setCartEmpty()
-                })
-            }
+            ordersApi.addOrdersGroup(orders, session._id).catch(() => {
+                setOrderStatus("Error")
+                setAlertMessage("Houve um erro com o seu pedido, um garçon irá confirmar o seu pedido em breve.")
+            }).then(() => {
+                setOrderStatus("Success")
+                setAlertMessage(`O seu pedido será levado á sua mesa em breve!`)
+                setCartEmpty()
+            })
+
             if (session && session._id)
                 invalidateOrdersKey()
         }


### PR DESCRIPTION
## Summary
- submit cart orders in a single request using `addOrdersGroup`
- send dashboard custom orders in bulk as well

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c2526dbbc83338fa3c5d14e78ab61