### PR TITLE
Add loading states for dashboard home

### DIFF
--- a/src/components/pages/dashboard-home/metric-card.tsx
+++ b/src/components/pages/dashboard-home/metric-card.tsx
@@ -4,10 +4,11 @@ import { MetricFormat } from "@/types/dashboard"
 
 interface MetricCardProps {
     title: string
-    value: number
+    value?: number
     growth: number
     icon: React.ComponentType<{ className?: string }>
     format?: MetricFormat
+    isLoading?: boolean
 }
 
 function formatValue(val: number, format: MetricFormat): string {
@@ -21,7 +22,7 @@ function formatValue(val: number, format: MetricFormat): string {
     }
 }
 
-export default function MetricCard({ title, value, growth, icon: Icon, format = "currency" }: MetricCardProps) {
+export default function MetricCard({ title, value, growth, icon: Icon, format = "currency", isLoading = false }: MetricCardProps) {
     const isPositive = growth > 0
     const GrowthIcon = isPositive ? TrendingUp : TrendingDown
 
@@ -32,12 +33,24 @@ export default function MetricCard({ title, value, growth, icon: Icon, format = 
                 <Icon className="h-4 w-4 text-purple-700" />
             </CardHeader>
             <CardContent>
-                <div className="text-2xl font-bold">{formatValue(value, format)}</div>
-                <div className="flex items-center space-x-1 text-xs">
-                    <GrowthIcon className={`h-3 w-3 ${isPositive ? "text-green-500" : "text-red-500"}`} />
-                    <span className={isPositive ? "text-green-500" : "text-red-500"}>{Math.abs(growth).toFixed(1)}%</span>
-                    <span className="text-muted-foreground">vs. período anterior</span>
-                </div>
+                {isLoading ? (
+                    <div className="flex items-center justify-center h-16">
+                        <span className="text-sm text-muted-foreground">A carregar...</span>
+                    </div>
+                ) : value === undefined ? (
+                    <div className="flex items-center justify-center h-16">
+                        <span className="text-sm text-muted-foreground">Sem dados disponíveis</span>
+                    </div>
+                ) : (
+                    <>
+                        <div className="text-2xl font-bold">{formatValue(value ?? 0, format)}</div>
+                        <div className="flex items-center space-x-1 text-xs">
+                            <GrowthIcon className={`h-3 w-3 ${isPositive ? "text-green-500" : "text-red-500"}`} />
+                            <span className={isPositive ? "text-green-500" : "text-red-500"}>{Math.abs(growth).toFixed(1)}%</span>
+                            <span className="text-muted-foreground">vs. período anterior</span>
+                        </div>
+                    </>
+                )}
             </CardContent>
         </Card>
     )

--- a/src/components/pages/dashboard-home/orders-chart.tsx
+++ b/src/components/pages/dashboard-home/orders-chart.tsx
@@ -4,12 +4,19 @@ import { Progress } from "@/components/ui/progress"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 
 export default function OrdersChart() {
-    const { ordersSummary, cancelledOrdersSummary } = useDashboardHomeContext()
+    const {
+        ordersSummary,
+        cancelledOrdersSummary,
+        isOrdersSummaryLoading,
+        isCancelledOrdersSummaryLoading,
+    } = useDashboardHomeContext()
 
     const totalOrders = ordersSummary?.orderCount ?? 0
     const cancelledOrders = cancelledOrdersSummary?.cancelledCount ?? 0
     const completedOrders = totalOrders - cancelledOrders
     const cancelledRate = totalOrders > 0 ? (cancelledOrders / totalOrders) * 100 : 0
+
+    const isLoading = isOrdersSummaryLoading || isCancelledOrdersSummaryLoading
 
     return (
         <Card>
@@ -18,22 +25,32 @@ export default function OrdersChart() {
                 <CardDescription>Comparação de pedidos realizados e cancelados</CardDescription>
             </CardHeader>
             <CardContent>
-                <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                        <span className="text-sm">Pedidos Realizados</span>
-                        <span className="font-medium">{completedOrders}</span>
+                {isLoading ? (
+                    <div className="flex items-center justify-center h-40">
+                        <span className="text-sm text-muted-foreground">A carregar...</span>
                     </div>
-                    <Progress value={(completedOrders / totalOrders) * 100} className="h-2" />
-                    <div className="flex items-center justify-between">
-                        <span className="text-sm">Pedidos Cancelados</span>
-                        <span className="font-medium">{cancelledOrders}</span>
+                ) : totalOrders === 0 ? (
+                    <div className="flex items-center justify-center h-40">
+                        <span className="text-sm text-muted-foreground">Sem dados disponíveis</span>
                     </div>
-                    <Progress value={(cancelledOrders / totalOrders) * 100} className="h-2" />
-                    <div className="flex items-center justify-between pt-2 border-t">
-                        <span className="text-sm font-medium">Taxa de Cancelamento</span>
-                        <Badge variant={cancelledRate > 15 ? "destructive" : "secondary"}>{cancelledRate.toFixed(1)}%</Badge>
+                ) : (
+                    <div className="space-y-4">
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm">Pedidos Realizados</span>
+                            <span className="font-medium">{completedOrders}</span>
+                        </div>
+                        <Progress value={(completedOrders / totalOrders) * 100} className="h-2" />
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm">Pedidos Cancelados</span>
+                            <span className="font-medium">{cancelledOrders}</span>
+                        </div>
+                        <Progress value={(cancelledOrders / totalOrders) * 100} className="h-2" />
+                        <div className="flex items-center justify-between pt-2 border-t">
+                            <span className="text-sm font-medium">Taxa de Cancelamento</span>
+                            <Badge variant={cancelledRate > 15 ? "destructive" : "secondary"}>{cancelledRate.toFixed(1)}%</Badge>
+                        </div>
                     </div>
-                </div>
+                )}
             </CardContent>
         </Card>
     )

--- a/src/components/pages/dashboard-home/popular-items-chart.tsx
+++ b/src/components/pages/dashboard-home/popular-items-chart.tsx
@@ -5,7 +5,12 @@ import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 import { ItemsTimeRange } from "@/types/dashboard"
 
 export default function PopularItemsChart() {
-    const { topItemsSummary, itemsTimeRange, setItemsTimeRange } = useDashboardHomeContext()
+    const {
+        topItemsSummary,
+        itemsTimeRange,
+        setItemsTimeRange,
+        isTopItemsSummaryLoading,
+    } = useDashboardHomeContext()
 
     return (
         <Card>
@@ -26,21 +31,30 @@ export default function PopularItemsChart() {
                 </Select>
             </CardHeader>
             <CardContent>
-                <div className="space-y-3">
-                    {/* TODO: Need to update the API to return an array of items */}
-                    {topItemsSummary && topItemsSummary.map((item, index) => (
-                        <div key={`${item.itemName}-${index}`} className="flex items-center space-x-3">
-                            <div className="w-8 text-sm font-medium text-muted-foreground">#{index + 1}</div>
-                            <div className="flex-1">
-                                <div className="flex items-center justify-between mb-1">
-                                    <span className="text-sm font-medium">{item.itemName}</span>
-                                    <span className="text-sm text-muted-foreground">{item.quantity}</span>
+                {isTopItemsSummaryLoading ? (
+                    <div className="flex items-center justify-center h-40">
+                        <span className="text-sm text-muted-foreground">A carregar...</span>
+                    </div>
+                ) : !topItemsSummary || topItemsSummary.length === 0 ? (
+                    <div className="flex items-center justify-center h-40">
+                        <span className="text-sm text-muted-foreground">Sem dados disponíveis</span>
+                    </div>
+                ) : (
+                    <div className="space-y-3">
+                        {topItemsSummary.map((item, index) => (
+                            <div key={`${item.itemName}-${index}`} className="flex items-center space-x-3">
+                                <div className="w-8 text-sm font-medium text-muted-foreground">#{index + 1}</div>
+                                <div className="flex-1">
+                                    <div className="flex items-center justify-between mb-1">
+                                        <span className="text-sm font-medium">{item.itemName}</span>
+                                        <span className="text-sm text-muted-foreground">{item.quantity}</span>
+                                    </div>
+                                    <Progress value={(item.quantity / topItemsSummary[0].quantity) * 100} className="h-1" />
                                 </div>
-                                <Progress value={(item.quantity / topItemsSummary[0].quantity) * 100} className="h-1" />
                             </div>
-                        </div>
-                    ))}
-                </div>
+                        ))}
+                    </div>
+                )}
             </CardContent>
         </Card>
     )

--- a/src/components/pages/dashboard-home/sales-chart.tsx
+++ b/src/components/pages/dashboard-home/sales-chart.tsx
@@ -3,7 +3,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 
 export default function SalesChart() {
-    const { lastSevenDaysOrdersCount } = useDashboardHomeContext()
+    const { lastSevenDaysOrdersCount, isLastSevenDaysOrdersCountLoading } = useDashboardHomeContext()
 
     const dayMap: Record<string, string> = {
         monday: "Seg",
@@ -25,29 +25,39 @@ export default function SalesChart() {
                 <CardDescription>Vendas diárias dos últimos 7 dias</CardDescription>
             </CardHeader>
             <CardContent>
-                <div className="h-[200px] flex items-end justify-between space-x-2">
-                    {salesData.map(data => (
-                        <TooltipProvider key={data.date}>
-                            <Tooltip>
-                                <TooltipTrigger className="w-full">
-                                    <div className="flex flex-col items-center space-y-2 flex-1">
-                                        <div
-                                            className="bg-primary rounded-t transition-all duration-500 hover:bg-primary/80 w-full"
-                                            style={{ height: `${(data.sales / maxSales) * 160}px` }}
-                                        />
-                                        <div className="flex flex-col items-center space-y-1">
-                                            <span className="text-xs text-muted-foreground">{dayMap[data.day] ?? data.day}</span>
-                                            <span className="text-xs text-muted-foreground">{`${data.date.slice(8, 10)}/${data.date.slice(5, 7)}/${data.date.slice(0, 4)}`}</span>
+                {isLastSevenDaysOrdersCountLoading ? (
+                    <div className="flex items-center justify-center h-[200px]">
+                        <span className="text-sm text-muted-foreground">A carregar...</span>
+                    </div>
+                ) : salesData.length === 0 ? (
+                    <div className="flex items-center justify-center h-[200px]">
+                        <span className="text-sm text-muted-foreground">Sem dados disponíveis</span>
+                    </div>
+                ) : (
+                    <div className="h-[200px] flex items-end justify-between space-x-2">
+                        {salesData.map(data => (
+                            <TooltipProvider key={data.date}>
+                                <Tooltip>
+                                    <TooltipTrigger className="w-full">
+                                        <div className="flex flex-col items-center space-y-2 flex-1">
+                                            <div
+                                                className="bg-primary rounded-t transition-all duration-500 hover:bg-primary/80 w-full"
+                                                style={{ height: `${(data.sales / maxSales) * 160}px` }}
+                                            />
+                                            <div className="flex flex-col items-center space-y-1">
+                                                <span className="text-xs text-muted-foreground">{dayMap[data.day] ?? data.day}</span>
+                                                <span className="text-xs text-muted-foreground">{`${data.date.slice(8, 10)}/${data.date.slice(5, 7)}/${data.date.slice(0, 4)}`}</span>
+                                            </div>
                                         </div>
-                                    </div>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    <span>{data.sales} pedidos</span>
-                                </TooltipContent>
-                            </Tooltip>
-                        </TooltipProvider>
-                    ))}
-                </div>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                        <span>{data.sales} pedidos</span>
+                                    </TooltipContent>
+                                </Tooltip>
+                            </TooltipProvider>
+                        ))}
+                    </div>
+                )}
             </CardContent>
         </Card>
     )

--- a/src/components/pages/dashboard-home/sessions-card.tsx
+++ b/src/components/pages/dashboard-home/sessions-card.tsx
@@ -4,7 +4,14 @@ import { Clock, TrendingUp, Users } from "lucide-react"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 
 export default function SessionsCard() {
-    const { sessionDurationSummary, activeSessionsSummary } = useDashboardHomeContext()
+    const {
+        sessionDurationSummary,
+        activeSessionsSummary,
+        isSessionDurationSummaryLoading,
+        isActiveSessionsSummaryLoading,
+    } = useDashboardHomeContext()
+
+    const isLoading = isSessionDurationSummaryLoading || isActiveSessionsSummaryLoading
 
     return (
         <Card>
@@ -13,52 +20,64 @@ export default function SessionsCard() {
                 <CardDescription>Duração e atividade das sessões</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                        <Clock className="h-4 w-4 text-muted-foreground" />
-                        <span className="text-sm">Duração Média</span>
+                {isLoading ? (
+                    <div className="flex items-center justify-center h-40">
+                        <span className="text-sm text-muted-foreground">A carregar...</span>
                     </div>
-                    <div className="text-right">
-                        <div className="font-medium">{sessionDurationSummary?.averageDurationMinutes ?? 0} min</div>
-                        <div className="flex items-center text-xs text-green-500">
-                            <TrendingUp className="h-3 w-3 mr-1" />
-                            {/* TODO: Need growth data */}
-                            0%
+                ) : !sessionDurationSummary && !activeSessionsSummary ? (
+                    <div className="flex items-center justify-center h-40">
+                        <span className="text-sm text-muted-foreground">Sem dados disponíveis</span>
+                    </div>
+                ) : (
+                    <>
+                        <div className="flex items-center justify-between">
+                            <div className="flex items-center space-x-2">
+                                <Clock className="h-4 w-4 text-muted-foreground" />
+                                <span className="text-sm">Duração Média</span>
+                            </div>
+                            <div className="text-right">
+                                <div className="font-medium">{sessionDurationSummary?.averageDurationMinutes ?? 0} min</div>
+                                <div className="flex items-center text-xs text-green-500">
+                                    <TrendingUp className="h-3 w-3 mr-1" />
+                                    {/* TODO: Need growth data */}
+                                    0%
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center space-x-2">
-                        <Users className="h-4 w-4 text-muted-foreground" />
-                        <span className="text-sm">Mesas ocupadas</span>
-                    </div>
-                    <div className="text-right">
-                        <div className="font-medium">{activeSessionsSummary?.activeSessions ?? 0}</div>
-                        <div className="hidden items-center text-xs text-green-500">
-                            <TrendingUp className="h-3 w-3 mr-1" />
-                            {/* TODO: Need growth data */}
-                            0%
+                        <div className="flex items-center justify-between">
+                            <div className="flex items-center space-x-2">
+                                <Users className="h-4 w-4 text-muted-foreground" />
+                                <span className="text-sm">Mesas ocupadas</span>
+                            </div>
+                            <div className="text-right">
+                                <div className="font-medium">{activeSessionsSummary?.activeSessions ?? 0}</div>
+                                <div className="hidden items-center text-xs text-green-500">
+                                    <TrendingUp className="h-3 w-3 mr-1" />
+                                    {/* TODO: Need growth data */}
+                                    0%
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-                <div className="pt-2">
-                    <div className="text-xs text-muted-foreground mb-2">Distribuição de Duração</div>
-                    <div className="flex space-x-1 h-16 items-end">
-                        {/* TODO: Need session duration distribution data */}
-                        {[20, 35, 45, 60, 40, 25, 15].map((height, index) => (
-                            <div
-                                key={`duration-${index}`}
-                                className="bg-primary/20 rounded-t flex-1 transition-all duration-300 hover:bg-primary/40"
-                                style={{ height: `${height}%` }}
-                            />
-                        ))}
-                    </div>
-                    <div className="flex justify-between text-xs text-muted-foreground mt-1">
-                        <span>0-30m</span>
-                        <span>30-60m</span>
-                        <span>60m+</span>
-                    </div>
-                </div>
+                        <div className="pt-2">
+                            <div className="text-xs text-muted-foreground mb-2">Distribuição de Duração</div>
+                            <div className="flex space-x-1 h-16 items-end">
+                                {/* TODO: Need session duration distribution data */}
+                                {[20, 35, 45, 60, 40, 25, 15].map((height, index) => (
+                                    <div
+                                        key={`duration-${index}`}
+                                        className="bg-primary/20 rounded-t flex-1 transition-all duration-300 hover:bg-primary/40"
+                                        style={{ height: `${height}%` }}
+                                    />
+                                ))}
+                            </div>
+                            <div className="flex justify-between text-xs text-muted-foreground mt-1">
+                                <span>0-30m</span>
+                                <span>30-60m</span>
+                                <span>60m+</span>
+                            </div>
+                        </div>
+                    </>
+                )}
             </CardContent>
         </Card>
     )

--- a/src/context/dashboard-home-context.ts
+++ b/src/context/dashboard-home-context.ts
@@ -26,6 +26,14 @@ export interface DashboardHomeContextProps {
     sessionDurationSummary?: AverageSessionDuration
     activeSessionsSummary?: ActiveSessionCount
     lastSevenDaysOrdersCount?: TotalOrdersCount[]
+    isSalesSummaryLoading: boolean
+    isInvoiceSummaryLoading: boolean
+    isOrdersSummaryLoading: boolean
+    isCancelledOrdersSummaryLoading: boolean
+    isTopItemsSummaryLoading: boolean
+    isSessionDurationSummaryLoading: boolean
+    isActiveSessionsSummaryLoading: boolean
+    isLastSevenDaysOrdersCountLoading: boolean
     insights: Insight[]
     handleExportCSV: () => Promise<void>
     handleExportPDF: () => Promise<void>

--- a/src/pages/dashboard/dashboard-home.tsx
+++ b/src/pages/dashboard/dashboard-home.tsx
@@ -150,32 +150,32 @@ export default function RestaurantDashboard(): JSX.Element {
     console.log(getDateRangeFromFilter(dateFilter).to)
 
     // Analytics hooks
-    const { data: salesSummary } = useGetSalesSummary({
+    const { data: salesSummary, isLoading: isSalesSummaryLoading } = useGetSalesSummary({
         restaurantId: restaurant._id,
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: invoiceSummary } = useGetInvoiceSummary({
+    const { data: invoiceSummary, isLoading: isInvoiceSummaryLoading } = useGetInvoiceSummary({
         restaurantId: restaurant._id,
         status: "completed",
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: ordersSummary } = useGetOrdersSummary({
+    const { data: ordersSummary, isLoading: isOrdersSummaryLoading } = useGetOrdersSummary({
         restaurantId: restaurant._id,
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: cancelledOrdersSummary } = useGetCancelledOrdersSummary({
+    const { data: cancelledOrdersSummary, isLoading: isCancelledOrdersSummaryLoading } = useGetCancelledOrdersSummary({
         restaurantId: restaurant._id,
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: topItemsSummary } = useGetTopItemsSummary({
+    const { data: topItemsSummary, isLoading: isTopItemsSummaryLoading } = useGetTopItemsSummary({
         restaurantId: restaurant._id,
         topN: 8,
         fromDate: getDateRangeFromFilter(itemsTimeRange).from,
@@ -185,15 +185,15 @@ export default function RestaurantDashboard(): JSX.Element {
     console.log("TOP:", topItemsSummary)
 
 
-    const { data: sessionDurationSummary } = useGetSessionDurationSummary({
+    const { data: sessionDurationSummary, isLoading: isSessionDurationSummaryLoading } = useGetSessionDurationSummary({
         restaurantId: restaurant._id
     })
 
-    const { data: activeSessionsSummary } = useGetActiveSessionsSummary({
+    const { data: activeSessionsSummary, isLoading: isActiveSessionsSummaryLoading } = useGetActiveSessionsSummary({
         restaurantId: restaurant._id
     })
 
-    const { data: lastSevenDaysOrdersCount } = useGetLastSevenDaysCount({
+    const { data: lastSevenDaysOrdersCount, isLoading: isLastSevenDaysOrdersCountLoading } = useGetLastSevenDaysCount({
         restaurantId: restaurant._id,
     })
 
@@ -290,6 +290,14 @@ export default function RestaurantDashboard(): JSX.Element {
             sessionDurationSummary,
             activeSessionsSummary,
             lastSevenDaysOrdersCount,
+            isSalesSummaryLoading,
+            isInvoiceSummaryLoading,
+            isOrdersSummaryLoading,
+            isCancelledOrdersSummaryLoading,
+            isTopItemsSummaryLoading,
+            isSessionDurationSummaryLoading,
+            isActiveSessionsSummaryLoading,
+            isLastSevenDaysOrdersCountLoading,
             insights,
             handleExportCSV,
             handleExportPDF,
@@ -299,11 +307,46 @@ export default function RestaurantDashboard(): JSX.Element {
                 <div className="mx-auto space-y-6">
                     <DashboardHomeHeader />
                     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
-                        <MetricCard title="Total de Vendas" value={salesSummary?.totalSales ?? 0} growth={0} icon={DollarSign} format="currency" />
-                        <MetricCard title="Faturas Emitidas" value={invoiceSummary?.invoiceCount ?? 0} growth={0} icon={Receipt} format="number" />
-                        <MetricCard title="Valor Médio por Fatura" value={salesSummary?.averageInvoice ?? 0} growth={0} icon={ShoppingCart} format="currency" />
-                        <MetricCard title="Mesas Servidas" value={salesSummary?.distinctTables ?? 0} growth={0} icon={Users} format="number" />
-                        <MetricCard title="Receita por Mesa" value={salesSummary?.revenuePerTable ?? 0} growth={0} icon={TrendingUp} format="currency" />
+                        <MetricCard
+                            title="Total de Vendas"
+                            value={salesSummary?.totalSales}
+                            growth={0}
+                            icon={DollarSign}
+                            format="currency"
+                            isLoading={isSalesSummaryLoading}
+                        />
+                        <MetricCard
+                            title="Faturas Emitidas"
+                            value={invoiceSummary?.invoiceCount}
+                            growth={0}
+                            icon={Receipt}
+                            format="number"
+                            isLoading={isInvoiceSummaryLoading}
+                        />
+                        <MetricCard
+                            title="Valor Médio por Fatura"
+                            value={salesSummary?.averageInvoice}
+                            growth={0}
+                            icon={ShoppingCart}
+                            format="currency"
+                            isLoading={isSalesSummaryLoading}
+                        />
+                        <MetricCard
+                            title="Mesas Servidas"
+                            value={salesSummary?.distinctTables}
+                            growth={0}
+                            icon={Users}
+                            format="number"
+                            isLoading={isSalesSummaryLoading}
+                        />
+                        <MetricCard
+                            title="Receita por Mesa"
+                            value={salesSummary?.revenuePerTable}
+                            growth={0}
+                            icon={TrendingUp}
+                            format="currency"
+                            isLoading={isSalesSummaryLoading}
+                        />
                     </div>
                     <div className="grid gap-6 lg:grid-cols-3">
                         <SalesChart />


### PR DESCRIPTION
## Summary
- show loaders when analytics data is being fetched
- display a friendly message when no data is available
- update dashboard home context to expose loading flags
- adjust metric card to handle loading/empty states

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c61a8bbcc83339d56eef3d3bb3ee6