### PR TITLE
Fix dashboard loading states when changing time range

### DIFF
--- a/src/api/endpoints/analytics/hooks.ts
+++ b/src/api/endpoints/analytics/hooks.ts
@@ -13,7 +13,7 @@ import {analyticsApi} from "@/api/endpoints/analytics/requests";
 
 export function useGetSalesSummary(params: SalesSummaryProps){
 
-    const queryKey = ["sales-summary", params.restaurantId];
+    const queryKey = ["sales-summary", params.restaurantId, params.fromDate, params.toDate];
 
     return useQuery({
         queryKey,
@@ -27,7 +27,7 @@ export function useGetSalesSummary(params: SalesSummaryProps){
 
 export function useGetInvoiceSummary(params: InvoicesSummaryProps){
 
-    const queryKey = ["invoices-summary", params.restaurantId];
+    const queryKey = ["invoices-summary", params.restaurantId, params.status, params.fromDate, params.toDate];
 
     return useQuery({
         queryKey,
@@ -39,7 +39,7 @@ export function useGetInvoiceSummary(params: InvoicesSummaryProps){
 
 export function useGetOrdersSummary(params: OrdersSummaryProps){
 
-    const queryKey = ["orders-summary", params.restaurantId];
+    const queryKey = ["orders-summary", params.restaurantId, params.fromDate, params.toDate];
 
     return useQuery({
         queryKey,
@@ -53,7 +53,7 @@ export function useGetOrdersSummary(params: OrdersSummaryProps){
 
 export function useGetTopItemsSummary(params: TopItemsSummaryProps){
 
-    const queryKey = ["top-items-summary", params.restaurantId];
+    const queryKey = ["top-items-summary", params.restaurantId, params.topN, params.fromDate, params.toDate];
 
     return useQuery({
         queryKey,
@@ -67,7 +67,7 @@ export function useGetTopItemsSummary(params: TopItemsSummaryProps){
 
 export function useGetCancelledOrdersSummary(params: CancelledOrdersSummaryProps){
 
-    const queryKey = ["cancelled orders summary", params.restaurantId];
+    const queryKey = ["cancelled orders summary", params.restaurantId, params.fromDate, params.toDate];
 
     return useQuery({
         queryKey,

--- a/src/pages/dashboard/dashboard-home.tsx
+++ b/src/pages/dashboard/dashboard-home.tsx
@@ -150,32 +150,32 @@ export default function RestaurantDashboard(): JSX.Element {
     console.log(getDateRangeFromFilter(dateFilter).to)
 
     // Analytics hooks
-    const { data: salesSummary, isLoading: isSalesSummaryLoading } = useGetSalesSummary({
+    const { data: salesSummary, isLoading: salesSummaryLoading, isFetching: salesSummaryFetching } = useGetSalesSummary({
         restaurantId: restaurant._id,
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: invoiceSummary, isLoading: isInvoiceSummaryLoading } = useGetInvoiceSummary({
+    const { data: invoiceSummary, isLoading: invoiceSummaryLoading, isFetching: invoiceSummaryFetching } = useGetInvoiceSummary({
         restaurantId: restaurant._id,
         status: "completed",
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: ordersSummary, isLoading: isOrdersSummaryLoading } = useGetOrdersSummary({
+    const { data: ordersSummary, isLoading: ordersSummaryLoading, isFetching: ordersSummaryFetching } = useGetOrdersSummary({
         restaurantId: restaurant._id,
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: cancelledOrdersSummary, isLoading: isCancelledOrdersSummaryLoading } = useGetCancelledOrdersSummary({
+    const { data: cancelledOrdersSummary, isLoading: cancelledOrdersSummaryLoading, isFetching: cancelledOrdersSummaryFetching } = useGetCancelledOrdersSummary({
         restaurantId: restaurant._id,
         fromDate: getDateRangeFromFilter(dateFilter).from,
         toDate: getDateRangeFromFilter(dateFilter).to
     })
 
-    const { data: topItemsSummary, isLoading: isTopItemsSummaryLoading } = useGetTopItemsSummary({
+    const { data: topItemsSummary, isLoading: topItemsSummaryLoading, isFetching: topItemsSummaryFetching } = useGetTopItemsSummary({
         restaurantId: restaurant._id,
         topN: 8,
         fromDate: getDateRangeFromFilter(itemsTimeRange).from,
@@ -185,19 +185,28 @@ export default function RestaurantDashboard(): JSX.Element {
     console.log("TOP:", topItemsSummary)
 
 
-    const { data: sessionDurationSummary, isLoading: isSessionDurationSummaryLoading } = useGetSessionDurationSummary({
+    const { data: sessionDurationSummary, isLoading: sessionDurationSummaryLoading, isFetching: sessionDurationSummaryFetching } = useGetSessionDurationSummary({
         restaurantId: restaurant._id
     })
 
-    const { data: activeSessionsSummary, isLoading: isActiveSessionsSummaryLoading } = useGetActiveSessionsSummary({
+    const { data: activeSessionsSummary, isLoading: activeSessionsSummaryLoading, isFetching: activeSessionsSummaryFetching } = useGetActiveSessionsSummary({
         restaurantId: restaurant._id
     })
 
-    const { data: lastSevenDaysOrdersCount, isLoading: isLastSevenDaysOrdersCountLoading } = useGetLastSevenDaysCount({
+    const { data: lastSevenDaysOrdersCount, isLoading: lastSevenDaysOrdersCountLoading, isFetching: lastSevenDaysOrdersCountFetching } = useGetLastSevenDaysCount({
         restaurantId: restaurant._id,
     })
 
     console.log("LAST:", lastSevenDaysOrdersCount)
+
+    const isSalesSummaryLoading = salesSummaryLoading || salesSummaryFetching
+    const isInvoiceSummaryLoading = invoiceSummaryLoading || invoiceSummaryFetching
+    const isOrdersSummaryLoading = ordersSummaryLoading || ordersSummaryFetching
+    const isCancelledOrdersSummaryLoading = cancelledOrdersSummaryLoading || cancelledOrdersSummaryFetching
+    const isTopItemsSummaryLoading = topItemsSummaryLoading || topItemsSummaryFetching
+    const isSessionDurationSummaryLoading = sessionDurationSummaryLoading || sessionDurationSummaryFetching
+    const isActiveSessionsSummaryLoading = activeSessionsSummaryLoading || activeSessionsSummaryFetching
+    const isLastSevenDaysOrdersCountLoading = lastSevenDaysOrdersCountLoading || lastSevenDaysOrdersCountFetching
 
 
     const getDateFilterLabel = useCallback((filter: DateFilter): string => {


### PR DESCRIPTION
## Summary
- include time range params in analytics query keys so queries refetch
- treat `isFetching` as loading in dashboard page so loading states display when filters change

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c67ec15f083339642994830c10407