### PR TITLE
Add useCallback to analytics query hooks

### DIFF
--- a/src/api/endpoints/analytics/hooks.ts
+++ b/src/api/endpoints/analytics/hooks.ts
@@ -7,6 +7,7 @@ import {
     SessionDurationSummaryProps,
     TopItemsSummaryProps
 } from "@/api/endpoints/analytics/types";
+import {useCallback} from "react";
 import {useQuery} from "@tanstack/react-query";
 import {analyticsApi} from "@/api/endpoints/analytics/requests";
 
@@ -15,10 +16,14 @@ export function useGetSalesSummary(params: SalesSummaryProps){
 
     const queryKey = ["sales-summary", params.restaurantId, params.fromDate, params.toDate];
 
+    const queryFn = useCallback(
+        () => analyticsApi.getSalesSummary(params).then(data => data),
+        [params.restaurantId, params.fromDate, params.toDate]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getSalesSummary(params)
-            .then(data => data),
+        queryFn,
         enabled: params.restaurantId != "notfound",
     })
 
@@ -29,9 +34,14 @@ export function useGetInvoiceSummary(params: InvoicesSummaryProps){
 
     const queryKey = ["invoices-summary", params.restaurantId, params.status, params.fromDate, params.toDate];
 
+    const queryFn = useCallback(
+        () => analyticsApi.getInvoicesSummary(params),
+        [params.restaurantId, params.status, params.fromDate, params.toDate]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getInvoicesSummary(params)
+        queryFn
 
     })
 
@@ -41,9 +51,14 @@ export function useGetOrdersSummary(params: OrdersSummaryProps){
 
     const queryKey = ["orders-summary", params.restaurantId, params.fromDate, params.toDate];
 
+    const queryFn = useCallback(
+        () => analyticsApi.getOrdersSummary(params),
+        [params.restaurantId, params.fromDate, params.toDate]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getOrdersSummary(params),
+        queryFn,
         enabled: params.restaurantId != "notfound",
 
     })
@@ -55,9 +70,14 @@ export function useGetTopItemsSummary(params: TopItemsSummaryProps){
 
     const queryKey = ["top-items-summary", params.restaurantId, params.topN, params.fromDate, params.toDate];
 
+    const queryFn = useCallback(
+        () => analyticsApi.getTopItemsSummary(params),
+        [params.restaurantId, params.topN, params.fromDate, params.toDate]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getTopItemsSummary(params),
+        queryFn,
         enabled: params.restaurantId != "notfound",
 
     })
@@ -69,9 +89,14 @@ export function useGetCancelledOrdersSummary(params: CancelledOrdersSummaryProps
 
     const queryKey = ["cancelled orders summary", params.restaurantId, params.fromDate, params.toDate];
 
+    const queryFn = useCallback(
+        () => analyticsApi.getCancelledOrdersSummary(params),
+        [params.restaurantId, params.fromDate, params.toDate]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getCancelledOrdersSummary(params),
+        queryFn,
         enabled: params.restaurantId != "notfound",
 
 
@@ -83,9 +108,14 @@ export function useGetSessionDurationSummary(params: SessionDurationSummaryProps
 
     const queryKey = ["session-duration", params.restaurantId];
 
+    const queryFn = useCallback(
+        () => analyticsApi.getSessionDurationSummary(params),
+        [params.restaurantId]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getSessionDurationSummary(params),
+        queryFn,
         enabled: params.restaurantId != "notfound",
 
     })
@@ -96,9 +126,14 @@ export function useGetActiveSessionsSummary(params: ActiveSessionsSummaryProps){
 
     const queryKey = ["active-sessions-summary", params.restaurantId];
 
+    const queryFn = useCallback(
+        () => analyticsApi.getActiveSessionsSummary(params),
+        [params.restaurantId]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getActiveSessionsSummary(params),
+        queryFn,
         enabled: params.restaurantId != "notfound",
 
     })
@@ -109,9 +144,14 @@ export function useGetLastSevenDaysCount (params: LastSevenDaysCount){
 
     const queryKey = ["last 7 days", params.restaurantId]
 
+    const queryFn = useCallback(
+        () => analyticsApi.getLastSevenDaysCount(params),
+        [params.restaurantId]
+    )
+
     return useQuery({
         queryKey,
-        queryFn: () => analyticsApi.getLastSevenDaysCount(params),
+        queryFn,
         enabled: params.restaurantId != "notfound",
 
     })


### PR DESCRIPTION
## Summary
- memoize query functions in analytics hooks with `useCallback`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c6f5719508333bbc2f707f1bb0866