### PR TITLE
Add role editing in staff table

### DIFF
--- a/src/api/endpoints/memberships/hooks.ts
+++ b/src/api/endpoints/memberships/hooks.ts
@@ -1,5 +1,6 @@
-import {useQuery} from "@tanstack/react-query";
+import {useMutation, useQuery, useQueryClient} from "@tanstack/react-query";
 import {membershipsApi} from "@/api/endpoints/memberships/requests";
+import {showSuccessToast, showErrorToast} from "@/utils/notifications/toast";
 
 
 export function useGetUserMemberships(userId: string, restaurantId: string) {
@@ -11,4 +12,20 @@ export function useGetUserMemberships(userId: string, restaurantId: string) {
         queryFn: () => membershipsApi.getUserMembership(userId, restaurantId)
     })
 
+}
+
+export function useUpdateMemberRole() {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: ({userId, restaurantId, roleId}: {userId: string, restaurantId: string, roleId: string}) =>
+            membershipsApi.updateRole(userId, restaurantId, roleId),
+        onSuccess: (_data, variables) => {
+            queryClient.invalidateQueries({queryKey: ["restaurant members", variables.restaurantId]})
+            showSuccessToast("Função atualizada")
+        },
+        onError: () => {
+            showErrorToast("Erro ao atualizar função")
+        }
+    })
 }

--- a/src/api/endpoints/memberships/requests.ts
+++ b/src/api/endpoints/memberships/requests.ts
@@ -19,6 +19,13 @@ export const membershipsApi = {
     deactivateMembership: async (userId: string, restaurantId: string) => {
         const result = await apiClient.put<User>(`${baseRoute}/${userId}/restaurant/${restaurantId}/deactivate`)
         return result.data
+    },
+
+    updateRole: async (userId: string, restaurantId: string, roleId: string) => {
+        const result = await apiClient.put<Membership>(
+            `${baseRoute}/${userId}/restaurant/${restaurantId}/role/${roleId}`
+        )
+        return result.data
     }
 
 

--- a/src/components/pages/dashboard-staff/members-table.tsx
+++ b/src/components/pages/dashboard-staff/members-table.tsx
@@ -3,6 +3,13 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue
+} from "@/components/ui/select"
+import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -18,6 +25,7 @@ import { useDashboardStaff } from "@/context/dashboard-staff-context"
 import {User} from "@/types/user";
 import {useGetUserMemberships} from "@/api/endpoints/memberships/hooks";
 import {useDashboardContext} from "@/context/dashboard-context";
+import {useListRestaurantRoles} from "@/hooks/use-list-restaurant-roles";
 
 export function MembersTable() {
 
@@ -83,7 +91,8 @@ function MemberRow({user}: {user: User}) {
         handleEditMember,
         handleDeleteMember,
         getRoleName,
-        getStatusBadge
+        getStatusBadge,
+        updateMemberRole
     } = useDashboardStaff()
 
     const {
@@ -93,6 +102,8 @@ function MemberRow({user}: {user: User}) {
     const {
         data: membership
     } = useGetUserMemberships(user._id, restaurant._id)
+
+    const { data: roles } = useListRestaurantRoles(restaurant._id)
 
     return (
         <TableRow key={user._id}>
@@ -117,11 +128,21 @@ function MemberRow({user}: {user: User}) {
                 </div>
             </TableCell>
             <TableCell>
-                <div>
-                    <Badge>
-                        {getRoleName(user.memberships[0]?.roleId)}
-                    </Badge>
-                </div>
+                <Select
+                    value={membership?.roleId ?? ""}
+                    onValueChange={(value) => updateMemberRole(user._id, value)}
+                >
+                    <SelectTrigger className="w-32 h-8">
+                        <SelectValue placeholder="Sem função" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {roles.map((role) => (
+                            <SelectItem key={role._id} value={role._id}>
+                                {role.name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
             </TableCell>
             <TableCell>
                 <div className="space-y-1">

--- a/src/context/dashboard-staff-context.tsx
+++ b/src/context/dashboard-staff-context.tsx
@@ -6,6 +6,7 @@ import { useDashboardContext } from "@/context/dashboard-context"
 import { useGetAllMembers } from "@/hooks/use-get-all-members"
 import { useListRestaurantRoles } from "@/hooks/use-list-restaurant-roles"
 import { showSuccessToast, showErrorToast } from "@/utils/notifications/toast"
+import { useUpdateMemberRole } from "@/api/endpoints/memberships/hooks"
 import { Badge } from "@/components/ui/badge"
 import { restaurantApi } from "@/api/endpoints/restaurants/requests"
 
@@ -60,6 +61,7 @@ interface DashboardStaffContextType {
     handleSelectAll: (checked: boolean) => void
     handleEditMember: (member: User) => void
     handleDeleteMember: (member: User) => void
+    updateMemberRole: (memberId: string, roleId: string) => void
     getRoleName: (roleId: string) => string
     getStatusBadge: (status: string) => JSX.Element
     handleBulkAction: (action: string) => void
@@ -100,6 +102,7 @@ export function DashboardStaffProvider({ children }: { children: ReactNode }) {
     })
 
     const { data: roles } = useListRestaurantRoles(restaurant._id)
+    const updateMemberRoleMutation = useUpdateMemberRole()
     const { data: users = [] } = useGetAllMembers({
         restaurantId: restaurant._id
     })
@@ -176,6 +179,14 @@ export function DashboardStaffProvider({ children }: { children: ReactNode }) {
         }
     }
 
+    const updateMemberRole = (memberId: string, roleId: string) => {
+        updateMemberRoleMutation.mutate({
+            userId: memberId,
+            restaurantId: restaurant._id,
+            roleId
+        })
+    }
+
     const getRoleName = (roleId: string) => {
         if (!roleId) return "Sem função"
         const role = roles?.find(r => r._id === roleId)
@@ -238,6 +249,7 @@ export function DashboardStaffProvider({ children }: { children: ReactNode }) {
             handleSelectAll,
             handleEditMember,
             handleDeleteMember,
+            updateMemberRole,
             getRoleName,
             getStatusBadge,
             handleBulkAction


### PR DESCRIPTION
## Summary
- allow editing a user's role in the staff table
- expose role update API and hook
- wire role update logic through dashboard staff context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c87b376b48333ac8f119e9a9b7fca