### PR TITLE
Add role editing dialog to staff page

### DIFF
--- a/src/api/endpoints/role/hook.ts
+++ b/src/api/endpoints/role/hook.ts
@@ -1,7 +1,8 @@
-import {useQuery, useQueryClient} from "@tanstack/react-query";
+import {useQuery, useQueryClient, useMutation} from "@tanstack/react-query";
 import {roleApi} from "@/api/endpoints/role/requests";
 import {User} from "@/types/user";
-import {Role} from "@/types/role";
+import {Role, PartialRole} from "@/types/role";
+import {showSuccessToast, showErrorToast} from "@/utils/notifications/toast";
 
 
 export function useGetRole(roleId: string | undefined) {
@@ -51,4 +52,22 @@ export function useListRestaurantRoles(restaurantId: string) {
         removeRole,
     }
 
+}
+
+export function useUpdateRole(restaurantId: string) {
+    const queryClient = useQueryClient()
+    const queryKey = ["roles", restaurantId]
+
+    return useMutation({
+        mutationFn: ({roleId, data}: {roleId: string; data: PartialRole}) => roleApi.updateRole(roleId, data),
+        onSuccess: (role) => {
+            queryClient.setQueryData<Role[]>(queryKey, (old = []) =>
+                old.map(r => r._id === role._id ? role : r)
+            )
+            showSuccessToast("Função atualizada com sucesso")
+        },
+        onError: () => {
+            showErrorToast("Erro ao atualizar função")
+        }
+    })
 }

--- a/src/hooks/use-list-restaurant-roles.ts
+++ b/src/hooks/use-list-restaurant-roles.ts
@@ -22,10 +22,17 @@ export function useListRestaurantRoles(restaurantId: string) {
         )
     }
 
+    const updateRole = (updated: Role) => {
+        queryClient.setQueryData<Role[]>(["roles", restaurantId], (old = []) =>
+            old.map(role => role._id === updated._id ? updated : role)
+        )
+    }
+
     return {
         data: data ? data : [],
         ...query,
         addRole,
-        removeRole
+        removeRole,
+        updateRole
     }
-} 
+}


### PR DESCRIPTION
## Summary
- add `useUpdateRole` hook for roles API
- enhance `useListRestaurantRoles` with `updateRole`
- enable editing roles with permissions and level in staff dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c901c337883339798ac9b7f37cf07