### PR TITLE
Fix item delete dialog close bug

### DIFF
--- a/src/components/pages/dashboard-menu/items-tab.tsx
+++ b/src/components/pages/dashboard-menu/items-tab.tsx
@@ -40,6 +40,11 @@ export function ItemsTab() {
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
     const [itemToDelete, setItemToDelete] = useState<Item | null>(null)
 
+    const handleCancelDelete = () => {
+        setDeleteDialogOpen(false)
+        setItemToDelete(null)
+    }
+
     const filteredItems = items? items.filter((item) => {
         const matchesSearch = item.name.toLowerCase().includes(searchTerm.toLowerCase())
         const matchesCategory = categoryFilter === "all" || item.categoryId === categoryFilter
@@ -268,7 +273,13 @@ export function ItemsTab() {
                     </p>
                 </div>
             )}
-            <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+            <AlertDialog
+                open={deleteDialogOpen}
+                onOpenChange={(open) => {
+                    if (!open) setItemToDelete(null)
+                    setDeleteDialogOpen(open)
+                }}
+            >
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Excluir item</AlertDialogTitle>
@@ -277,7 +288,9 @@ export function ItemsTab() {
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                        <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                        <AlertDialogCancel onClick={handleCancelDelete}>
+                            Cancelar
+                        </AlertDialogCancel>
                         <AlertDialogAction onClick={confirmDeleteItem} className="bg-red-600 hover:bg-red-700">
                             Excluir
                         </AlertDialogAction>


### PR DESCRIPTION
## Summary
- ensure delete dialog resets item state on cancel
- close the dialog when cancelling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ddd0ad8348333b3416c622f5e8816