### PR TITLE
Implement table monitor hooks and websockets

### DIFF
--- a/docs/table-monitor-page.md
+++ b/docs/table-monitor-page.md
@@ -36,4 +36,6 @@ This document describes the planned **Table Monitor** page used by staff to foll
 5. **Cleaning a Table**
    - If the client leaves without paying, the staff uses **Limpar Mesa**. This cancels outstanding orders, cancels the session and immediately starts a new empty session for the table so it becomes available again.
 
+The implementation fetches tables using `useListRestaurantTables` and active sessions via `sessionApi.listActiveSessions`. A WebSocket connection (`/ws/{restaurantId}/session-status`) keeps the table state updated in real time. Actions such as marking the bill as paid or cleaning the table call the corresponding API helpers.
+
 The page therefore centralises table activity so waiters can react quickly to customer requests and keep track of which tables are in use.

--- a/src/api/endpoints/sessions/requests.ts
+++ b/src/api/endpoints/sessions/requests.ts
@@ -32,7 +32,7 @@ export const sessionApi = {
     },
 
     listActiveSessions: async (restaurantId: string) => {
-        const response = await apiClient.get<TableSession>(`${baseRoute}/restaurant/${restaurantId}/active`);
+        const response = await apiClient.get<TableSession[]>(`${baseRoute}/restaurant/${restaurantId}/active`);
         return response.data;
     },
 


### PR DESCRIPTION
## Summary
- refactor table monitor page to use API hooks for tables, sessions and orders
- listen to `/ws/{restaurantId}/session-status` for real time updates
- update docs for implementation notes
- fix `listActiveSessions` return type

## Testing
- `npm run lint` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68606539ee988333bf758cbefed5ed61