### PR TITLE
Update order tracking filters and custom order link

### DIFF
--- a/src/components/pages/dashboard-orders/header.tsx
+++ b/src/components/pages/dashboard-orders/header.tsx
@@ -4,12 +4,17 @@ import {Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTri
 import {useState} from "react";
 import {SortAscending, SortDescending, ArrowRight} from "@phosphor-icons/react"
 import {FILTERS, Tag} from "@/pages/dashboard/order-tracking";
+import type {OrderPrepStatus} from "@/types/order";
 import {useOrdersTrackingContext} from "@/context/orders-tracking-context";
 
 
-export function Header() {
+interface HeaderProps {
+    customOrderUrl: string;
+}
 
-    const { filterMode, handleFilterModeChange, orders, handleTableFilterChange, sorting, handleSortingChange} = useOrdersTrackingContext()
+export function Header({ customOrderUrl }: HeaderProps) {
+
+    const { activeFilters, toggleFilter, clearFilters, orders, handleTableFilterChange, sorting, handleSortingChange} = useOrdersTrackingContext()
     const [isSheetOpen, setIsSheetOpen] = useState<boolean>(false)
 
     function toggleSheet() {
@@ -39,18 +44,22 @@ export function Header() {
                             </SheetHeader>
                             <div className="flex flex-col gap-2">
                                 {
-                                    FILTERS.map((filter) =>
-                                        filter.tag === filterMode.tag ?
-                                            <Button key={filter.tag} className="text-sm bg-amethyst text-white hover:bg-amethyst-400" variant="secondary">
-                                                {filter.name}
-                                            </Button>:
-                                            <Button onClick={() => {
-                                                handleFilterModeChange(filter)
-                                                toggleSheet()
-                                            }} key={filter.tag} className="text-sm bg-white" variant="secondary">
+                                    FILTERS.map((filter) => {
+                                        if (filter.tag === 'all') {
+                                            const active = activeFilters.length === 0
+                                            return (
+                                                <Button key={filter.tag} onClick={clearFilters} className={active ? "text-sm bg-amethyst text-white hover:bg-amethyst-400" : "text-sm bg-white"} variant="secondary">
+                                                    {filter.name}
+                                                </Button>
+                                            )
+                                        }
+                                        const active = activeFilters.includes(filter.tag as OrderPrepStatus)
+                                        return (
+                                            <Button onClick={() => toggleFilter(filter.tag as OrderPrepStatus)} key={filter.tag} className={active ? "text-sm bg-amethyst text-white hover:bg-amethyst-400" : "text-sm bg-white"} variant="secondary">
                                                 {filter.name}
                                             </Button>
-                                    )
+                                        )
+                                    })
                                 }
                             </div>
 
@@ -60,15 +69,22 @@ export function Header() {
                 <div className="lg:flex items-center gap-2 hidden">
 
                     {
-                        FILTERS.map((filter) =>
-                            filter.tag === filterMode.tag ?
-                                <Button key={filter.tag} className="text-sm bg-amethyst border-[1.5px] border-zinc-300 bg-zinc-200 text-[#70469f] hover:bg-amethyst-400" variant="secondary">
-                                    {filter.name}
-                                </Button>:
-                                <Button onClick={() => handleFilterModeChange(filter)} key={filter.tag} className="text-sm bg-white" variant="secondary">
+                        FILTERS.map((filter) => {
+                            if (filter.tag === 'all') {
+                                const active = activeFilters.length === 0
+                                return (
+                                    <Button key={filter.tag} onClick={clearFilters} className={active ? "text-sm bg-amethyst border-[1.5px] border-zinc-300 bg-zinc-200 text-[#70469f] hover:bg-amethyst-400" : "text-sm bg-white"} variant="secondary">
+                                        {filter.name}
+                                    </Button>
+                                )
+                            }
+                            const active = activeFilters.includes(filter.tag as OrderPrepStatus)
+                            return (
+                                <Button onClick={() => toggleFilter(filter.tag as OrderPrepStatus)} key={filter.tag} className={active ? "text-sm bg-amethyst border-[1.5px] border-zinc-300 bg-zinc-200 text-[#70469f] hover:bg-amethyst-400" : "text-sm bg-white"} variant="secondary">
                                     {filter.name}
                                 </Button>
-                        )
+                            )
+                        })
                     }
                 </div>
             </div>
@@ -109,6 +125,11 @@ export function Header() {
                         }
                     </Button>
                 </div>
+                <Button variant="outline" asChild>
+                    <a href={customOrderUrl} target="_blank" rel="noopener noreferrer">
+                        Registar Pedido
+                    </a>
+                </Button>
             </div>
         </div>
     );

--- a/src/components/pages/dashboard-orders/orders-display.tsx
+++ b/src/components/pages/dashboard-orders/orders-display.tsx
@@ -4,12 +4,10 @@ import {OrderListing} from "@/components/pages/dashboard-orders/order-listing";
 
 export function OrdersDisplay() {
 
-    const {orders, filterMode, tableFilter, sorting} = useOrdersTrackingContext()
+    const {orders, activeFilters, tableFilter, sorting} = useOrdersTrackingContext()
 
     const filteredOrders = orders.filter((order) => {
-        console.log("FILTERING ORDERS:")
-        console.log(order)
-        const matchesFilterMode = filterMode.tag === 'all' || filterMode.tag === order.prepStatus;
+        const matchesFilterMode = activeFilters.length === 0 || activeFilters.includes(order.prepStatus);
         const matchesTableFilter = tableFilter === "all" || tableFilter === null || tableFilter === (order.tableNumber?.toString() ?? null);
         return matchesFilterMode && matchesTableFilter;
     }).sort((a, b) => {

--- a/src/context/orders-tracking-context.ts
+++ b/src/context/orders-tracking-context.ts
@@ -1,6 +1,5 @@
 import {createContext, useContext} from "react";
-import {Order} from "@/types/order";
-import {Filter} from "@/pages/dashboard/order-tracking";
+import {Order, OrderPrepStatus} from "@/types/order";
 
 
 interface OrdersTrackingContextProps {
@@ -8,8 +7,9 @@ interface OrdersTrackingContextProps {
     handleOrderSelected: (order: Order) => void;
     handleOrderDeselected: () => void;
     orders: Order[]
-    filterMode: Filter,
-    handleFilterModeChange: (filterMode: Filter) => void
+    activeFilters: OrderPrepStatus[],
+    toggleFilter: (status: OrderPrepStatus) => void,
+    clearFilters: () => void,
     tableFilter: string | null,
     handleTableFilterChange: (tableFilter: string | null) => void,
     updateOrderStatus: (orderId: string, newStatus: string) => void


### PR DESCRIPTION
## Summary
- allow mixing multiple order status filters
- rework order tracking context accordingly
- move "Registar Pedido" button into the header and open in new tab
- update order display filtering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860a39ec428833392faf7ea93cad3a1