### PR TITLE
Update table status logic

### DIFF
--- a/src/pages/dashboard/table-monitor.tsx
+++ b/src/pages/dashboard/table-monitor.tsx
@@ -19,11 +19,15 @@ import { showPromiseToast } from "@/utils/notifications/toast"
 
 type TableStatus = "disponivel" | "ocupada" | "conta_pedida" | "chamando_funcionario"
 
-const getTableStatus = (table: Table, sessions: Record<string, TableSession>): TableStatus => {
+const getTableStatus = (
+    table: Table,
+    sessions: Record<string, TableSession>
+): TableStatus => {
     const session = sessions[table._id]
     if (!session) return "disponivel"
     if (session.status === "needs bill") return "conta_pedida"
-    return "ocupada"
+    if (session.orders && session.orders.length > 0) return "ocupada"
+    return "disponivel"
 }
 
 const getStatusConfig = (status: TableStatus) => {


### PR DESCRIPTION
## Summary
- use session orders to mark a table as unavailable
- show table as free when it has a session but no orders

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860b2adde488333bcd679a5039956dd