### PR TITLE
Prevent ordering after bill request

### DIFF
--- a/src/components/pages/restaurant-menu-cart/checkout.tsx
+++ b/src/components/pages/restaurant-menu-cart/checkout.tsx
@@ -4,9 +4,10 @@ import {OrderAlert} from "@/components/pages/restaurant-menu-cart/order-alert";
 
 interface Props {
     onSubmit: () => void,
+    disabled?: boolean
 }
 
-export function Checkout({onSubmit}: Props) {
+export function Checkout({onSubmit, disabled = false}: Props) {
 
     const {setCustomerName, totalValue} = useCartContext()
 
@@ -41,9 +42,14 @@ export function Checkout({onSubmit}: Props) {
                                           className="peer w-full text-base resize-none rounded-b-none border-b border-gray-300 bg-transparent pb-1.5 text-blue-gray-700 outline outline-0 transition-all placeholder-shown:border-blue-gray-200 focus:border-gray-900 focus:outline-0 disabled:resize-none disabled:border-0 disabled:bg-blue-gray-50 duration-200">
 
                                 </textarea>
-                            <div onClick={onSubmit}>
-                                <OrderAlert/>
+                            <div onClick={!disabled ? onSubmit : undefined}>
+                                <OrderAlert disabled={disabled}/>
                             </div>
+                            {disabled && (
+                                <p className="text-center text-xs text-red-600 mt-2">
+                                    A conta foi solicitada. Novos pedidos não são permitidos.
+                                </p>
+                            )}
                         </form>
                     </div>
                 </div>

--- a/src/components/pages/restaurant-menu-cart/order-alert.tsx
+++ b/src/components/pages/restaurant-menu-cart/order-alert.tsx
@@ -12,14 +12,28 @@ import {Button} from "@/components/ui/button";
 import {useCartContext} from "@/context/cart-context";
 
 
-export function OrderAlert() {
+interface Props {
+    disabled?: boolean
+}
+
+export function OrderAlert({disabled = false}: Props) {
 
     const {alertMessage, orderStatus, customerName, totalValue, iSFetchingSession} = useCartContext()
+
+    const isDisabled = iSFetchingSession || disabled
+
+    if (isDisabled || totalValue === 0) {
+        return (
+            <Button disabled className={`w-full cursor-not-allowed bg-zinc-600 pt-2`}>
+                Confirmar
+            </Button>
+        )
+    }
 
     return (
         <AlertDialog>
             <AlertDialogTrigger asChild className={`w-full pt-2`}>
-                <Button disabled={iSFetchingSession} className={`w-full ${totalValue === 0 && "cursor-not-allowed bg-zinc-600"}`}>
+                <Button className="w-full">
                     Confirmar
                 </Button>
             </AlertDialogTrigger>

--- a/src/pages/dashboard/table-monitor.tsx
+++ b/src/pages/dashboard/table-monitor.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Separator } from "@/components/ui/separator"
-import { Clock, Users, CreditCard, AlertTriangle, Play, Trash2, CheckCircle } from "lucide-react"
+import { Clock, Users, CreditCard, AlertTriangle, Play, Trash2, CheckCircle, XCircle } from "lucide-react"
 import type { Table } from "@/types/table"
 import type { TableSession } from "@/types/table-session"
 import { useDashboardContext } from "@/context/dashboard-context"
@@ -160,6 +160,22 @@ export default function TableMonitor() {
             loading: "Limpando mesa...",
             success: "Mesa limpa",
             error: "Erro ao limpar mesa"
+        })
+        setIsSheetOpen(false)
+    }
+
+    const handleCancelCheckout = (sessionId: string) => {
+        const promise = sessionApi.cancelCheckout(sessionId).then((updated) => {
+            setSessions((prev) => {
+                const entry = Object.values(prev).find((s) => s._id === sessionId)
+                if (!entry) return prev
+                return { ...prev, [entry.tableId]: { ...entry, status: "active" } }
+            })
+        })
+        showPromiseToast(promise, {
+            loading: "Cancelando conta...",
+            success: "Conta cancelada",
+            error: "Erro ao cancelar conta"
         })
         setIsSheetOpen(false)
     }
@@ -345,6 +361,12 @@ export default function TableMonitor() {
 
                                             {/* Actions */}
                                             <div className="space-y-3">
+                                                {selectedSession.status === "needs bill" && (
+                                                    <Button onClick={() => handleCancelCheckout(selectedSession._id)} variant="outline" className="w-full" size="lg">
+                                                        <XCircle className="h-4 w-4 mr-2" />
+                                                        Cancelar Conta
+                                                    </Button>
+                                                )}
                                                 <Button onClick={() => handleMarkAsPaid(selectedSession._id)} className="w-full" size="lg">
                                                     <CreditCard className="h-4 w-4 mr-2" />
                                                     Marcar como Paga

--- a/src/pages/restaurant/cart.tsx
+++ b/src/pages/restaurant/cart.tsx
@@ -1,4 +1,4 @@
-import {useState} from "react";
+import {useState, useEffect} from "react";
 import {useParams} from "react-router";
 import {useQueryClient} from "@tanstack/react-query";
 import {useCart} from "@/hooks/use-cart";
@@ -11,6 +11,7 @@ import {NumberOfItems} from "@/components/pages/restaurant-menu-cart/number-of-i
 import {Checkout} from "@/components/pages/restaurant-menu-cart/checkout";
 import {ItemsSection} from "@/components/pages/restaurant-menu-cart/items-section";
 import {ordersApi} from "@/api/endpoints/orders/requests";
+import {showWarningToast} from "@/utils/notifications/toast";
 
 export function Cart() {
 
@@ -49,6 +50,14 @@ export function Cart() {
         restaurantId: restaurant._id
     })
 
+    const billRequested = session?.status === "needs bill"
+
+    useEffect(() => {
+        if (billRequested) {
+            showWarningToast("Conta já solicitada. Novos pedidos estão desabilitados.")
+        }
+    }, [billRequested])
+
     function invalidateOrdersKey() {
         const key = ["active", tableNumber, restaurant._id]
         queryClient.invalidateQueries({
@@ -57,6 +66,11 @@ export function Cart() {
     }
 
     function handleSubmit() {
+        if (session?.status === "needs bill") {
+            showWarningToast("A conta já foi solicitada. Não é possível fazer novos pedidos.")
+            return
+        }
+
         const items = cart.map((item) => item)
 
         if (session && session?._id) {
@@ -110,7 +124,7 @@ export function Cart() {
                 <ReturnNav path={`..`} title={"Carrinho"}/>
                 <NumberOfItems/>
                 <ItemsSection/>
-                <Checkout onSubmit={handleSubmit}/>
+                <Checkout onSubmit={handleSubmit} disabled={billRequested}/>
             </div>
         </CartContext.Provider>
     );


### PR DESCRIPTION
## Summary
- prevent new orders when bill was requested and notify the user
- disable checkout components after bill request
- allow cancelling checkout from table monitor sheet

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(fails: TS6305 output file has not been built)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc1d17e083339ff5a5488298144e