### PR TITLE
Show customisations in order tracking

### DIFF
--- a/src/components/pages/dashboard-orders/order-info.tsx
+++ b/src/components/pages/dashboard-orders/order-info.tsx
@@ -105,6 +105,25 @@ export function OrderInfo({order}: OrderInfoProps) {
                     </div>
                 </div>
             }
+            {
+                order.customisations && order.customisations.length > 0 &&
+                <div>
+                    <Separator className="my-4"/>
+                    <div>
+                        <h1 className="font-poppins-regular text-zinc-500">
+                            Personalizações:
+                        </h1>
+                        <Card className="p-4 bg-zinc-100 rounded-2xl my-2 border-amethyst-300 space-y-1.5">
+                            {order.customisations.map((c) => (
+                                <p key={c.ruleName} className="text-sm font-poppins-regular text-zinc-800">
+                                    <span className="font-medium">{c.ruleName}: </span>
+                                    {c.selectedOptions.map(o => `${o.optionName} (${o.quantity})`).join(', ')}
+                                </p>
+                            ))}
+                        </Card>
+                    </div>
+                </div>
+            }
             <Separator className="my-4"/>
             <div className="mb-12 lg:mb-0">
                 <h1 className="font-poppins-semibold text-zinc-500 my-2">

--- a/src/pages/dashboard/order-tracking.tsx
+++ b/src/pages/dashboard/order-tracking.tsx
@@ -139,7 +139,7 @@ export function OrdersTracking() {
                                 <div className="space-y-4 h-max lg:flex lg:flex-1 lg:flex-col">
                                     <Header customOrderUrl={`/custom-order/${restaurant.slug}`} />
                                     <div
-                                        className={`flex flex-1 rounded-2xl w-full `}>
+                                        className={`flex flex-1 rounded-2xl w-full overflow-hidden`}>
                                         {
                                             orders.length == 0 ?
                                                 <div
@@ -154,7 +154,7 @@ export function OrdersTracking() {
                                                 </div> :
                                                 <>
                                                     <div
-                                                        className={`transition-all lg:flex lg:flex-col lg:flex-1 overflow-y-hidden lg:flex-grow duration-150 ease-in-out w-full ${orderSelected === null ? 'w-full' : 'lg:w-3/5'}`}>
+                                                        className={`transition-all lg:flex lg:flex-col lg:flex-1 overflow-y-hidden lg:flex-grow duration-150 ease-in-out w-full ${orderSelected === null ? 'w-full' : 'lg:w-1/2'}`}>
                                                         <ScrollArea className="w-full rounded-l-2xl lg:flex-1 lg:flex lg:flex-col">
                                                             <div className=" ">
                                                                 <OrdersDisplay/>
@@ -164,7 +164,7 @@ export function OrdersTracking() {
                                                     {
                                                         isDesktop ?
                                                             <div
-                                                                className={` transition-all duration-150 ease-in-out ${orderSelected === null ? 'lg:hidden' : 'lg:block'}`}>
+                                                                className={` transition-all duration-150 ease-in-out ${orderSelected === null ? 'lg:hidden' : 'lg:block lg:w-1/2 lg:sticky lg:top-0'}`}> 
                                                                 {orderSelected && <OrderInfo order={orderSelected}/>}
                                                             </div> :
                                                             <MobileOrderInfo order={orderSelected}


### PR DESCRIPTION
## Summary
- display selected customisations in the order info panel
- widen the order info panel and keep it visible while scrolling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860c2afee308333b23f5e33a64e7b79