### PR TITLE
Switch table monitor to Kwanza currency

### DIFF
--- a/src/pages/dashboard/table-monitor.tsx
+++ b/src/pages/dashboard/table-monitor.tsx
@@ -73,9 +73,9 @@ const formatDuration = (startTime: string) => {
 }
 
 const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("pt-BR", {
+    return new Intl.NumberFormat("pt-AO", {
         style: "currency",
-        currency: "EUR",
+        currency: "AOA",
     }).format(amount)
 }
 


### PR DESCRIPTION
## Summary
- change currency formatting on the table monitoring page to use Angolan Kwanza

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6860c60b46b483339c564a8653b8ba5e