### PR TITLE
Adjust role display and filtering

### DIFF
--- a/src/components/pages/dashboard-staff/member-row.tsx
+++ b/src/components/pages/dashboard-staff/member-row.tsx
@@ -27,6 +27,7 @@ import { ptBR } from "date-fns/locale"
 import { Clock, Edit, Eye, Mail, MoreHorizontal, Phone, Trash2 } from "lucide-react"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Badge } from "@/components/ui/badge"
+import { getRoleLabel } from "@/utils/user/role-translations"
 
 interface MemberRowProps {
     user: User
@@ -81,8 +82,8 @@ export default function MemberRow({ user }: MemberRowProps) {
                 </TableCell>
                 <TableCell>
                     <Select
-                        defaultValue={membership?.roleId}
-                        value={membership?.roleId ?? ""}
+                        defaultValue={membership?.roleId && membership.roleId !== 'no_role' ? membership.roleId : undefined}
+                        value={membership?.roleId && membership.roleId !== 'no_role' ? membership.roleId : ""}
                         onValueChange={(value) => updateMemberRole(user._id, value)}
                     >
                         <SelectTrigger className="w-32 h-8">
@@ -91,7 +92,7 @@ export default function MemberRow({ user }: MemberRowProps) {
                         <SelectContent>
                             {roles.map((role) => (
                                 <SelectItem key={role._id} value={role._id}>
-                                    {role.name}
+                                    {getRoleLabel(role.name)}
                                 </SelectItem>
                             ))}
                         </SelectContent>
@@ -149,7 +150,7 @@ export default function MemberRow({ user }: MemberRowProps) {
                     </SheetHeader>
                     <div className="p-4 space-y-3 overflow-y-auto h-full">
                         <div>
-                            <p className="font-semibold">Função: {role?.name || "Sem função"}</p>
+                            <p className="font-semibold">Função: {role ? getRoleLabel(role.name) : "Sem função"}</p>
                             {role?.description && <p className="text-sm text-muted-foreground">{role.description}</p>}
                         </div>
                         <div className="space-y-2">

--- a/src/context/dashboard-staff-context.tsx
+++ b/src/context/dashboard-staff-context.tsx
@@ -8,6 +8,7 @@ import { useListRestaurantRoles } from "@/hooks/use-list-restaurant-roles"
 import { showSuccessToast, showErrorToast } from "@/utils/notifications/toast"
 import { useUpdateMemberRole } from "@/api/endpoints/memberships/hooks"
 import { Badge } from "@/components/ui/badge"
+import { getRoleLabel } from "@/utils/user/role-translations"
 import { restaurantApi } from "@/api/endpoints/restaurants/requests"
 
 type SortableUserFields = keyof Pick<User, 'firstName' | 'lastName' | 'email' | 'isActive' | 'updatedAt'>
@@ -191,7 +192,9 @@ export function DashboardStaffProvider({ children }: { children: ReactNode }) {
     const getRoleName = (roleId: string) => {
         if (!roleId) return "Sem função"
         const role = roles?.find(r => r._id === roleId)
-        return role?.name || "Sem função"
+        if (!role) return "Sem função"
+        if (role.name === "no_role") return "Sem função"
+        return getRoleLabel(role.name)
     }
 
 

--- a/src/hooks/use-list-restaurant-roles.ts
+++ b/src/hooks/use-list-restaurant-roles.ts
@@ -12,6 +12,8 @@ export function useListRestaurantRoles(restaurantId: string) {
         queryFn: () => roleApi.listRestaurantRoles(restaurantId)
     })
 
+    const filtered = (data ?? []).filter(r => r.name !== 'no_role')
+
     const addRole = (role: Role) => {
         queryClient.setQueryData<Role[]>(["roles", restaurantId], (old = []) => [...old, role])
     }
@@ -29,7 +31,7 @@ export function useListRestaurantRoles(restaurantId: string) {
     }
 
     return {
-        data: data ? data : [],
+        data: filtered,
         ...query,
         addRole,
         removeRole,

--- a/src/pages/dashboard/staff.tsx
+++ b/src/pages/dashboard/staff.tsx
@@ -4,6 +4,7 @@ import {RoleCreate, SectionPermission, Role, PartialRole, Sections} from "@/type
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { getRoleLabel } from "@/utils/user/role-translations"
 import { Invitation, InvitationCreate } from "@/types/invitation"
 
 import {
@@ -423,7 +424,7 @@ function StaffContent() {
                                                         <div key={role._id} className="flex items-center justify-between p-3 border rounded-lg">
                                                             <div className="flex-1">
                                                                 <div className="flex items-center gap-2">
-                                                                    <Badge>{role.name}</Badge>
+                                                                    <Badge>{getRoleLabel(role.name)}</Badge>
                                                                     <Badge variant="outline">Personalizada</Badge>
                                                                 </div>
                                                                 <p className="text-sm text-gray-600 mt-1">{role.description}</p>
@@ -652,7 +653,7 @@ function StaffContent() {
                                                         <SelectContent>
                                                             {roles.map((role) => (
                                                                 <SelectItem key={role._id} value={role._id}>
-                                                                    {role.name}
+                                                                    {getRoleLabel(role.name)}
                                                                 </SelectItem>
                                                             ))}
                                                         </SelectContent>

--- a/src/utils/user/role-translations.ts
+++ b/src/utils/user/role-translations.ts
@@ -1,0 +1,13 @@
+export const ROLE_LABELS: Record<string, string> = {
+  owner: 'Proprietário',
+  manager: 'Gerente',
+  waiter: 'Atendente',
+  cashier: 'Caixa',
+  chef: 'Chef',
+  bartender: 'Barman',
+  admin: 'Administrador',
+};
+
+export function getRoleLabel(name: string): string {
+  return ROLE_LABELS[name] ?? name;
+}


### PR DESCRIPTION
## Summary
- create utility for translating role names to Portuguese
- filter out `no_role` entries in role list
- show translated role labels in staff management UI
- avoid selecting or displaying `no_role` for members

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68615bc2039c8333835d8de588d62163