### PR TITLE
Translate role sections & skip no_role

### DIFF
--- a/src/components/pages/dashboard-staff/invitations-table.tsx
+++ b/src/components/pages/dashboard-staff/invitations-table.tsx
@@ -66,11 +66,12 @@ function InvitationRow({ invitation }: { invitation: Invitation }) {
     }
 
     const {data: role} = useGetRole(invitation.roleId)
+    const roleName = role?.name === "no_role" ? "Sem função" : role?.name ?? "Carregando..."
 
     return (
         <TableRow>
             <TableCell>{invitation.name}</TableCell>
-            <TableCell>{role?.name ?? "Carregando..."}</TableCell>
+            <TableCell>{roleName}</TableCell>
             <TableCell>{format(new Date(invitation.createdAt), "dd/MM/yyyy", { locale: ptBR })}</TableCell>
             <TableCell className="flex justify-end gap-2">
                 <Button variant="ghost" size="sm" onClick={handleCopy}>

--- a/src/components/pages/dashboard-staff/member-row.tsx
+++ b/src/components/pages/dashboard-staff/member-row.tsx
@@ -27,6 +27,7 @@ import { ptBR } from "date-fns/locale"
 import { Clock, Edit, Eye, Mail, MoreHorizontal, Phone, Trash2 } from "lucide-react"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Badge } from "@/components/ui/badge"
+import { getSectionLabel } from "@/lib/helpers/section-label"
 
 interface MemberRowProps {
     user: User
@@ -44,12 +45,14 @@ export default function MemberRow({ user }: MemberRowProps) {
 
     const { restaurant } = useDashboardContext()
     const { data: roles } = useListRestaurantRoles(restaurant._id)
+    const filteredRoles = (roles ?? []).filter(r => r.name !== "no_role")
 
     const membership = user.memberships[0]
     const [isMenuOpen, setIsMenuOpen] = useState(false)
     const [isSheetOpen, setIsSheetOpen] = useState(false)
 
     const role = roles.find((r) => r._id === membership?.roleId)
+    const roleName = role?.name === "no_role" || !role ? "Sem função" : role.name
 
     function handleViewPermissions() {
         setIsMenuOpen(false)
@@ -81,15 +84,15 @@ export default function MemberRow({ user }: MemberRowProps) {
                 </TableCell>
                 <TableCell>
                     <Select
-                        defaultValue={membership?.roleId}
-                        value={membership?.roleId ?? ""}
+                        defaultValue={role?.name === "no_role" ? "" : membership?.roleId}
+                        value={role?.name === "no_role" ? "" : (membership?.roleId ?? "")}
                         onValueChange={(value) => updateMemberRole(user._id, value)}
                     >
                         <SelectTrigger className="w-32 h-8">
                             <SelectValue placeholder="Sem função" />
                         </SelectTrigger>
                         <SelectContent>
-                            {roles.map((role) => (
+                            {filteredRoles.map((role) => (
                                 <SelectItem key={role._id} value={role._id}>
                                     {role.name}
                                 </SelectItem>
@@ -149,13 +152,13 @@ export default function MemberRow({ user }: MemberRowProps) {
                     </SheetHeader>
                     <div className="p-4 space-y-3 overflow-y-auto h-full">
                         <div>
-                            <p className="font-semibold">Função: {role?.name || "Sem função"}</p>
+                            <p className="font-semibold">Função: {roleName}</p>
                             {role?.description && <p className="text-sm text-muted-foreground">{role.description}</p>}
                         </div>
                         <div className="space-y-2">
                             {role?.permissions.map((perm) => (
                                 <div key={perm.section} className="flex items-start justify-between">
-                                    <span className="capitalize">{perm.section.replace(/_/g, " ")}</span>
+                                    <span className="capitalize">{getSectionLabel(perm.section)}</span>
                                     <div className="flex gap-1">
                                         {perm.permissions.canView && <Badge variant="secondary">ver</Badge>}
                                         {perm.permissions.canEdit && <Badge variant="secondary">editar</Badge>}

--- a/src/context/dashboard-staff-context.tsx
+++ b/src/context/dashboard-staff-context.tsx
@@ -191,7 +191,8 @@ export function DashboardStaffProvider({ children }: { children: ReactNode }) {
     const getRoleName = (roleId: string) => {
         if (!roleId) return "Sem função"
         const role = roles?.find(r => r._id === roleId)
-        return role?.name || "Sem função"
+        if (!role || role.name === "no_role") return "Sem função"
+        return role.name
     }
 
 

--- a/src/lib/helpers/section-label.ts
+++ b/src/lib/helpers/section-label.ts
@@ -1,0 +1,47 @@
+export const sectionLabels: Record<string, string> = {
+    menus: 'Cardápios',
+    categories: 'Categorias',
+    items: 'Itens',
+    customizations: 'Customizações',
+    orders: 'Pedidos',
+
+    customer_orders_summary: 'Resumo de Pedidos',
+    table_qr_access_control: 'Controle de Acesso QR da Mesa',
+
+    kitchen_view: 'Visão da Cozinha',
+    bar_view: 'Visão do Bar',
+    order_queue: 'Fila de Pedidos',
+    tables: 'Mesas',
+    reservations: 'Reservas',
+
+    users: 'Usuários',
+    roles: 'Funções',
+    permissions: 'Permissões',
+
+    sales_dashboard: 'Painel de Vendas',
+    invoices: 'Faturas',
+    payments: 'Pagamentos',
+    reports: 'Relatórios',
+
+    performance_insights: 'Visão de Desempenho',
+    product_popularity: 'Popularidade dos Produtos',
+    revenue_trends: 'Tendências de Receita',
+    customer_feedback: 'Feedback dos Clientes',
+
+    restaurant_settings: 'Configurações do Restaurante',
+    opening_hours: 'Horário de Funcionamento',
+    printer_setup: 'Configuração da Impressora',
+    table_qr_configuration: 'Configuração QR da Mesa',
+
+    promotions: 'Promoções',
+    announcements: 'Anúncios',
+    customer_reviews: 'Avaliações de Clientes',
+
+    system_logs: 'Logs do Sistema',
+    integration_settings: 'Configurações de Integração',
+    help_requests: 'Pedidos de Ajuda',
+};
+
+export function getSectionLabel(section: string): string {
+    return sectionLabels[section] ?? section.replace(/_/g, ' ');
+}

--- a/src/pages/dashboard/staff.tsx
+++ b/src/pages/dashboard/staff.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { User } from "@/types/user"
 import {RoleCreate, SectionPermission, Role, PartialRole, Sections} from "@/types/role"
+import { getSectionLabel } from "@/lib/helpers/section-label"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -145,6 +146,8 @@ function StaffContent() {
         removeRole,
         updateRole
     } = useListRestaurantRoles(restaurant._id)
+
+    const filteredRoles = (roles ?? []).filter(r => r.name !== "no_role")
 
     const { data: users = [] } = useGetAllMembers({
         restaurantId: restaurant._id
@@ -419,7 +422,7 @@ function StaffContent() {
 
                                             <TabsContent value="existing" className="space-y-4">
                                                 <div className="space-y-3 max-h-64 overflow-y-auto">
-                                                    {roles.map((role) => (
+                                                    {filteredRoles.map((role) => (
                                                         <div key={role._id} className="flex items-center justify-between p-3 border rounded-lg">
                                                             <div className="flex-1">
                                                                 <div className="flex items-center gap-2">
@@ -493,7 +496,7 @@ function StaffContent() {
                                                                                     htmlFor={`role-${permission.section}`}
                                                                                     className="text-sm font-medium leading-none"
                                                                                 >
-                                                                                    {permission.section.replace(/_/g, ' ')}
+    {getSectionLabel(permission.section)}
                                                                                 </Label>
                                                                                 <p className="text-xs text-muted-foreground">
                                                                                     Permissões:
@@ -547,7 +550,7 @@ function StaffContent() {
                                                     <div key={perm.section} className="border p-3 rounded-lg space-y-2">
                                                         <div className="flex items-center justify-between">
                                                             <Label className="capitalize">
-                                                                {perm.section.replace(/_/g, " ")}
+                                                                {getSectionLabel(perm.section)}
                                                             </Label>
                                                             <Button
                                                                 variant="ghost"
@@ -584,7 +587,7 @@ function StaffContent() {
                                                     </SelectTrigger>
                                                     <SelectContent>
                                                         {Object.values(Sections).map(sec => (
-                                                            <SelectItem key={sec} value={sec}>{sec.replace(/_/g, ' ')}</SelectItem>
+                                                            <SelectItem key={sec} value={sec}>{getSectionLabel(sec)}</SelectItem>
                                                         ))}
                                                     </SelectContent>
                                                 </Select>
@@ -650,13 +653,13 @@ function StaffContent() {
                                                             <SelectValue placeholder="Selecione uma função" />
                                                         </SelectTrigger>
                                                         <SelectContent>
-                                                            {roles.map((role) => (
+                                                            {filteredRoles.map((role) => (
                                                                 <SelectItem key={role._id} value={role._id}>
                                                                     {role.name}
                                                                 </SelectItem>
                                                             ))}
                                                         </SelectContent>
-                                                    </Select>
+                                                   </Select>
                                                 </div>
                                             </div>
 


### PR DESCRIPTION
## Summary
- translate permission section labels to Portuguese
- prevent "no_role" from being shown as an option
- show "Sem função" whenever a role is `no_role`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68615d2ec1f48333bb408869091f5d9b