### PR TITLE
Improve editing UX

### DIFF
--- a/src/components/pages/dashboard-menu/overview-tab.tsx
+++ b/src/components/pages/dashboard-menu/overview-tab.tsx
@@ -39,6 +39,15 @@ export function OverviewTab({ menu, onUpdate }: OverviewTabProps) {
         setIsEditingDescription(false)
     }
 
+    const handleBlur = (field: "name" | "description") => (e: React.FocusEvent<HTMLElement>) => {
+        const related = e.relatedTarget as HTMLElement | null
+        if (related?.dataset?.action === "cancel") {
+            field === "name" ? handleNameCancel() : handleDescriptionCancel()
+        } else {
+            field === "name" ? handleNameSave() : handleDescriptionSave()
+        }
+    }
+
     const handlePreferenceChange = (key: keyof typeof menu.preferences, value: boolean) => {
         onUpdate({
             preferences: {
@@ -65,19 +74,20 @@ export function OverviewTab({ menu, onUpdate }: OverviewTabProps) {
                                     id="menu-name"
                                     value={tempName}
                                     onChange={(e) => setTempName(e.target.value)}
+                                    onBlur={handleBlur("name")}
                                     className="flex-1"
                                     autoFocus
                                 />
                                 <Button size="sm" onClick={handleNameSave}>
                                     <Check className="h-4 w-4" />
                                 </Button>
-                                <Button size="sm" variant="outline" onClick={handleNameCancel}>
+                                <Button size="sm" variant="outline" data-action="cancel" onClick={handleNameCancel}>
                                     <X className="h-4 w-4" />
                                 </Button>
                             </div>
                         ) : (
-                            <div className="flex items-center gap-2 group">
-                                <div className="flex-1 p-2 border border-transparent rounded-md hover:border-gray-200 transition-colors">
+                            <div className="flex items-center gap-2 group" onClick={() => setIsEditingName(true)}>
+                                <div className="flex-1 p-2 border border-transparent rounded-md hover:border-gray-200 transition-colors cursor-text">
                                     <span className="text-sm font-medium">{menu.name}</span>
                                 </div>
                                 <Button
@@ -101,6 +111,7 @@ export function OverviewTab({ menu, onUpdate }: OverviewTabProps) {
                                     id="menu-description"
                                     value={tempDescription}
                                     onChange={(e) => setTempDescription(e.target.value)}
+                                    onBlur={handleBlur("description")}
                                     rows={3}
                                     autoFocus
                                 />
@@ -109,15 +120,15 @@ export function OverviewTab({ menu, onUpdate }: OverviewTabProps) {
                                         <Check className="h-4 w-4 mr-2" />
                                         Salvar
                                     </Button>
-                                    <Button size="sm" variant="outline" onClick={handleDescriptionCancel}>
+                                    <Button size="sm" variant="outline" data-action="cancel" onClick={handleDescriptionCancel}>
                                         <X className="h-4 w-4 mr-2" />
                                         Cancelar
                                     </Button>
                                 </div>
                             </div>
                         ) : (
-                            <div className="group">
-                                <div className="p-2 border border-transparent rounded-md hover:border-gray-200 transition-colors min-h-[80px] flex items-start justify-between">
+                            <div className="group" onClick={() => setIsEditingDescription(true)}>
+                                <div className="p-2 border border-transparent rounded-md hover:border-gray-200 transition-colors min-h-[80px] flex items-start justify-between cursor-text">
                                     <p className="text-sm text-gray-600 flex-1">{menu.description}</p>
                                     <Button
                                         size="sm"

--- a/src/pages/dashboard/menu/categories/category.tsx
+++ b/src/pages/dashboard/menu/categories/category.tsx
@@ -192,6 +192,15 @@ export default function CategoryDetailsPage() {
         }
     }
 
+    const handleBlur = (field: string) => (e: React.FocusEvent<HTMLElement>) => {
+        const related = e.relatedTarget as HTMLElement | null
+        if (related?.dataset?.action === "cancel") {
+            cancelEditing(field)
+        } else {
+            saveField(field)
+        }
+    }
+
     const handleTagKeyPress = (e: React.KeyboardEvent) => {
         if (e.key === "Enter") {
             e.preventDefault()
@@ -260,19 +269,20 @@ export default function CategoryDetailsPage() {
                                                 value={editValues.name || ""}
                                                 onChange={(e) => handleInputChange("name", e.target.value)}
                                                 onKeyDown={(e) => handleKeyPress(e, "name")}
+                                                onBlur={handleBlur("name")}
                                                 className={errors.name ? "border-red-500" : ""}
                                                 autoFocus
                                             />
                                             <Button size="sm" onClick={() => saveField("name")}>
                                                 <Save className="h-4 w-4" />
                                             </Button>
-                                            <Button size="sm" variant="outline" onClick={() => cancelEditing("name")}>
+                                            <Button size="sm" variant="outline" data-action="cancel" onClick={() => cancelEditing("name")}>
                                                 <X className="h-4 w-4" />
                                             </Button>
                                         </div>
                                     ) : (
-                                        <div className="flex items-center justify-between group">
-                                            <span className="text-lg font-medium">{category.name}</span>
+                                        <div className="flex items-center justify-between group" onClick={() => startEditing("name") }>
+                                            <span className="text-lg font-medium cursor-text">{category.name}</span>
                                             <Button
                                                 size="sm"
                                                 variant="ghost"
@@ -294,6 +304,7 @@ export default function CategoryDetailsPage() {
                                             <Textarea
                                                 value={editValues.description || ""}
                                                 onChange={(e) => handleInputChange("description", e.target.value)}
+                                                onBlur={handleBlur("description")}
                                                 className={`${errors.description ? "border-red-500" : ""}`}
                                                 rows={3}
                                                 autoFocus
@@ -303,15 +314,15 @@ export default function CategoryDetailsPage() {
                                                     <Save className="h-4 w-4 mr-2" />
                                                     Salvar
                                                 </Button>
-                                                <Button size="sm" variant="outline" onClick={() => cancelEditing("description")}>
+                                                <Button size="sm" variant="outline" data-action="cancel" onClick={() => cancelEditing("description")}>
                                                     <X className="h-4 w-4 mr-2" />
                                                     Cancelar
                                                 </Button>
                                             </div>
                                         </div>
                                     ) : (
-                                        <div className="group">
-                                            <div className="flex items-start justify-between p-3 border border-transparent rounded-md hover:border-gray-200 transition-colors">
+                                        <div className="group" onClick={() => startEditing("description") }>
+                                            <div className="flex items-start justify-between p-3 border border-transparent rounded-md hover:border-gray-200 transition-colors cursor-text">
                                                 <p className="text-gray-700 flex-1">{category.description}</p>
                                                 <Button
                                                     size="sm"
@@ -338,19 +349,20 @@ export default function CategoryDetailsPage() {
                                                 value={editValues.position || 0}
                                                 onChange={(e) => handleInputChange("position", Number.parseInt(e.target.value) || 0)}
                                                 onKeyDown={(e) => handleKeyPress(e, "position")}
+                                                onBlur={handleBlur("position")}
                                                 className={`w-24 ${errors.position ? "border-red-500" : ""}`}
                                                 autoFocus
                                             />
                                             <Button size="sm" onClick={() => saveField("position")}>
                                                 <Save className="h-4 w-4" />
                                             </Button>
-                                            <Button size="sm" variant="outline" onClick={() => cancelEditing("position")}>
+                                            <Button size="sm" variant="outline" data-action="cancel" onClick={() => cancelEditing("position")}>
                                                 <X className="h-4 w-4" />
                                             </Button>
                                         </div>
                                     ) : (
-                                        <div className="flex items-center justify-between group">
-                                            <span className="text-gray-700">Posição {category.position}</span>
+                                        <div className="flex items-center justify-between group" onClick={() => startEditing("position") }>
+                                            <span className="text-gray-700 cursor-text">Posição {category.position}</span>
                                             <Button
                                                 size="sm"
                                                 variant="ghost"

--- a/src/pages/dashboard/menu/items/item.tsx
+++ b/src/pages/dashboard/menu/items/item.tsx
@@ -272,6 +272,15 @@ export default function ItemDetailsPage() {
         }
     }
 
+    const handleBlur = (field: string) => (e: React.FocusEvent<HTMLElement>) => {
+        const related = e.relatedTarget as HTMLElement | null
+        if (related?.dataset?.action === "cancel") {
+            cancelEditing(field)
+        } else {
+            saveField(field)
+        }
+    }
+
     if (isLoading || !item) {
         return <div>Loading...</div>
     }
@@ -340,19 +349,20 @@ export default function ItemDetailsPage() {
                                                         value={editValues?.name || ""}
                                                         onChange={(e) => handleInputChange("name", e.target.value)}
                                                         onKeyDown={(e) => handleKeyPress(e, "name")}
+                                                        onBlur={handleBlur("name")}
                                                         className={errors.name ? "border-red-500" : ""}
                                                         autoFocus
                                                     />
                                                     <Button size="sm" onClick={() => saveField("name")}>
                                                         <Save className="h-4 w-4" />
                                                     </Button>
-                                                    <Button size="sm" variant="outline" onClick={() => cancelEditing("name")}>
+                                                    <Button size="sm" variant="outline" data-action="cancel" onClick={() => cancelEditing("name")}>
                                                         <X className="h-4 w-4" />
                                                     </Button>
                                                 </div>
                                             ) : (
-                                                <div className="flex items-center justify-between group">
-                                                    <span className="text-lg font-medium">{item.name}</span>
+                                                <div className="flex items-center justify-between group" onClick={() => startEditing("name") }>
+                                                    <span className="text-lg font-medium cursor-text">{item.name}</span>
                                                     <Button
                                                         size="sm"
                                                         variant="ghost"
@@ -380,6 +390,7 @@ export default function ItemDetailsPage() {
                                                             value={editValues?.price || 0}
                                                             onChange={(e) => handleInputChange("price", Number.parseFloat(e.target.value) || 0)}
                                                             onKeyDown={(e) => handleKeyPress(e, "price")}
+                                                            onBlur={handleBlur("price")}
                                                             className={`pl-10 ${errors.price ? "border-red-500" : ""}`}
                                                             autoFocus
                                                         />
@@ -387,13 +398,13 @@ export default function ItemDetailsPage() {
                                                     <Button size="sm" onClick={() => saveField("price")}>
                                                         <Save className="h-4 w-4" />
                                                     </Button>
-                                                    <Button size="sm" variant="outline" onClick={() => cancelEditing("price")}>
+                                                    <Button size="sm" variant="outline" data-action="cancel" onClick={() => cancelEditing("price")}>
                                                         <X className="h-4 w-4" />
                                                     </Button>
                                                 </div>
                                             ) : (
-                                                <div className="flex items-center justify-between group">
-                                                    <span className="text-lg font-medium text-green-600">${item.price.toFixed(2)}</span>
+                                                <div className="flex items-center justify-between group" onClick={() => startEditing("price") }>
+                                                    <span className="text-lg font-medium text-green-600 cursor-text">${item.price.toFixed(2)}</span>
                                                     <Button
                                                         size="sm"
                                                         variant="ghost"
@@ -414,7 +425,7 @@ export default function ItemDetailsPage() {
                                                 <div className="flex items-center gap-2">
                                                     <Select
                                                         value={editValues?.categoryId || ""}
-                                                        onValueChange={(value) => handleInputChange("categoryId", value)}
+                                                        onValueChange={(value) => {handleInputChange("categoryId", value); saveField("categoryId")}}
                                                     >
                                                         <SelectTrigger className={errors.categoryId ? "border-red-500" : ""}>
                                                             <SelectValue placeholder="Select category" />
@@ -430,13 +441,13 @@ export default function ItemDetailsPage() {
                                                     <Button size="sm" onClick={() => saveField("categoryId")}> 
                                                         <Save className="h-4 w-4" />
                                                     </Button>
-                                                    <Button size="sm" variant="outline" onClick={() => cancelEditing("categoryId")}> 
+                                                    <Button size="sm" variant="outline" data-action="cancel" onClick={() => cancelEditing("categoryId")}>
                                                         <X className="h-4 w-4" />
                                                     </Button>
                                                 </div>
                                             ) : (
-                                                <div className="flex items-center justify-between group">
-                                                    <span className="text-lg font-medium">{getCategoryName(item.categoryId)}</span>
+                                                <div className="flex items-center justify-between group" onClick={() => startEditing("categoryId") }>
+                                                    <span className="text-lg font-medium cursor-text">{getCategoryName(item.categoryId)}</span>
                                                     <Button
                                                         size="sm"
                                                         variant="ghost"
@@ -458,6 +469,7 @@ export default function ItemDetailsPage() {
                                                     <Textarea
                                                         value={editValues?.description || ""}
                                                         onChange={(e) => handleInputChange("description", e.target.value)}
+                                                        onBlur={handleBlur("description")}
                                                         rows={3}
                                                         autoFocus
                                                     />
@@ -466,15 +478,15 @@ export default function ItemDetailsPage() {
                                                             <Save className="h-4 w-4 mr-2" />
                                                             Save
                                                         </Button>
-                                                        <Button size="sm" variant="outline" onClick={() => cancelEditing("description")}>
+                                                        <Button size="sm" variant="outline" data-action="cancel" onClick={() => cancelEditing("description")}>
                                                             <X className="h-4 w-4 mr-2" />
                                                             Cancel
                                                         </Button>
                                                     </div>
                                                 </div>
                                             ) : (
-                                                <div className="group">
-                                                    <div className="flex items-start justify-between p-3 border border-transparent rounded-md hover:border-gray-200 transition-colors">
+                                                <div className="group" onClick={() => startEditing("description") }>
+                                                    <div className="flex items-start justify-between p-3 border border-transparent rounded-md hover:border-gray-200 transition-colors cursor-text">
                                                         <p className="text-gray-700 flex-1">{item.description || "No description provided"}</p>
                                                         <Button
                                                             size="sm"


### PR DESCRIPTION
## Summary
- ease editing by making labels clickable
- auto-save on blur
- avoid accidental save when canceling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6861967f1a888333bbc164dc90e787aa