### PR TITLE
Fix staff role dropdown not updating

### DIFF
--- a/src/api/endpoints/memberships/hooks.ts
+++ b/src/api/endpoints/memberships/hooks.ts
@@ -21,6 +21,7 @@ export function useUpdateMemberRole() {
         mutationFn: ({userId, restaurantId, roleId}: {userId: string, restaurantId: string, roleId: string}) =>
             membershipsApi.updateRole(userId, restaurantId, roleId),
         onSuccess: (_data, variables) => {
+            queryClient.invalidateQueries({queryKey: ["members", variables.restaurantId]})
             queryClient.invalidateQueries({queryKey: ["restaurant members", variables.restaurantId]})
             showSuccessToast("Função atualizada")
         },


### PR DESCRIPTION
## Summary
- invalidate the `members` query on member role updates so the staff table reflects the new role selection immediately

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68619ad0ee98833390f4af19b74ca784