### PR TITLE
Use addMembership in invitation signup

### DIFF
--- a/src/api/endpoints/memberships/requests.ts
+++ b/src/api/endpoints/memberships/requests.ts
@@ -28,8 +28,8 @@ export const membershipsApi = {
         return result.data
     },
 
-    g: async (userId: string, roleId: string) => {
-        const response = await apiClient.post<User>(`${baseRoute}/`, {data: {userId, roleId}})
+    addMembership: async (userId: string, roleId: string) => {
+        const response = await apiClient.post<User>(`${baseRoute}/`, { userId, roleId })
         return response.data
     }
 

--- a/src/pages/dashboard/invitation.tsx
+++ b/src/pages/dashboard/invitation.tsx
@@ -130,9 +130,8 @@ export default function RestaurantInvitation() {
           },
         });
 
-        await membershipsApi.updateRole(
+        await membershipsApi.addMembership(
           user._id,
-          invitation.restaurantId,
           invitation.roleId
         );
         await membershipsApi.activateMembership(
@@ -175,9 +174,8 @@ export default function RestaurantInvitation() {
           },
         });
 
-        await membershipsApi.updateRole(
+        await membershipsApi.addMembership(
           user._id,
-          invitation.restaurantId,
           invitation.roleId
         );
         await membershipsApi.activateMembership(


### PR DESCRIPTION
## Summary
- add `addMembership` endpoint for creating memberships
- use `addMembership` in invitation signup flow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a5d31250833385a002a637561b5b