### PR TITLE
Delete invitation after account creation

### DIFF
--- a/src/pages/dashboard/invitation.tsx
+++ b/src/pages/dashboard/invitation.tsx
@@ -14,6 +14,7 @@ import { useGetRestaurant } from "@/api/endpoints/restaurants/hooks";
 import { useGetRole } from "@/api/endpoints/role/hook";
 import { useGetUser } from "@/api/endpoints/user/hooks";
 import { membershipsApi } from "@/api/endpoints/memberships/requests";
+import { invitationApi } from "@/api/endpoints/invitation/requests";
 import { showPromiseToast } from "@/utils/notifications/toast";
 import { useGoogleAuth } from "@/hooks/use-google-auth";
 import { createUserWithEmailAndPassword } from "firebase/auth";
@@ -138,6 +139,7 @@ export default function RestaurantInvitation() {
           user._id,
           invitation.restaurantId
         );
+        await invitationApi.deleteInvitation(invitation._id);
       })
       .then(() => navigate("/dashboard"));
 
@@ -182,6 +184,7 @@ export default function RestaurantInvitation() {
           user._id,
           invitation.restaurantId
         );
+        await invitationApi.deleteInvitation(invitation._id);
       })
       .then(() => navigate("/dashboard"));
 


### PR DESCRIPTION
## Summary
- remove invitations after signup workflow completes successfully

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861a89852ac83339ce94384b828ea42