### PR TITLE
Finish profile preferences mutation

### DIFF
--- a/src/api/endpoints/user/hooks.ts
+++ b/src/api/endpoints/user/hooks.ts
@@ -1,6 +1,8 @@
 import {useAuth} from "@/context/auth-context";
 import {useMutation, useQuery, useQueryClient} from "@tanstack/react-query";
 import {userApi} from "@/api/endpoints/user/endpoints";
+import {Preferences} from "@/types/user";
+import {showSuccessToast, showErrorToast} from "@/utils/notifications/toast";
 
 
 export function useGetUserRestaurants(){
@@ -59,6 +61,22 @@ export function useSetCurrentRestaurant() {
         onSuccess: () => {
             // Invalidate so useGetCurrentRestaurant picks up the new value
             queryClient.invalidateQueries({ queryKey: ["currentRestaurantId"] });
+        },
+    });
+}
+
+export function useUpdatePreferences() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (preferences: Preferences) => userApi.updatePreferences(preferences),
+        onSuccess: (user) => {
+            queryClient.setQueryData(["me"], user);
+            queryClient.invalidateQueries({ queryKey: ["me"] });
+            showSuccessToast("Preferences updated successfully");
+        },
+        onError: () => {
+            showErrorToast("Failed to update preferences");
         },
     });
 }

--- a/src/pages/dashboard/profile.tsx
+++ b/src/pages/dashboard/profile.tsx
@@ -1,5 +1,4 @@
 
-// TODO: implement updateUserPreferences API hook and use it in this page
 import { useEffect, useMemo, useState } from "react"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
@@ -31,6 +30,7 @@ import { restaurantApi } from "@/api/endpoints/restaurants/requests";
 import { roleApi } from "@/api/endpoints/role/requests";
 import { useQueryClient } from "@tanstack/react-query";
 import { showSuccessToast, showErrorToast } from "@/utils/notifications/toast";
+import { useUpdatePreferences } from "@/api/endpoints/user/hooks";
 import { Loader } from "@/components/ui/loader";
 
 export default function UserProfile() {
@@ -39,6 +39,7 @@ export default function UserProfile() {
     const [roles, setRoles] = useState<Record<string, Role>>({})
     const [restaurants, setRestaurants] = useState<Record<string, Restaurant>>({})
     const queryClient = useQueryClient()
+    const updatePreferencesMutation = useUpdatePreferences()
 
     useEffect(() => {
         if (me) setUser(me)
@@ -78,16 +79,13 @@ export default function UserProfile() {
 
     const handlePreferenceChange = (key: keyof UserType["preferences"], value: boolean | string) => {
         if (!user) return;
-        setUser((prev) => prev ? ({
-            ...prev,
-            preferences: {
-                ...prev.preferences,
-                [key]: value,
-            },
-        }): prev)
+        const newPrefs = {
+            ...user.preferences,
+            [key]: value,
+        }
+        setUser(prev => prev ? ({ ...prev, preferences: newPrefs }) : prev)
 
-        // TODO: call updateUserPreferences mutation when available
-        showSuccessToast("Preferences updated successfully")
+        updatePreferencesMutation.mutate(newPrefs)
     }
 
     const restaurantMemberships = useMemo(() => {


### PR DESCRIPTION
## Summary
- add updatePreferences React Query hook
- persist preference changes in dashboard profile page

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6861b0fb0ed88333ad28b848defee6b0