### PR TITLE
Fix order info not updating on status change

### DIFF
--- a/src/pages/dashboard/order-tracking.tsx
+++ b/src/pages/dashboard/order-tracking.tsx
@@ -56,6 +56,13 @@ export function OrdersTracking() {
 
     const { data: orders, addOrder, removeOrders, updateOrderStatus, isLoading } = useGetRecentOrders(restaurant._id)
 
+    const updateOrderAndSelectionStatus = useCallback((orderId: string, newStatus: string) => {
+        updateOrderStatus(orderId, newStatus)
+        if (orderSelected && orderSelected._id === orderId) {
+            handleState({ ...orderSelected, prepStatus: newStatus })
+        }
+    }, [updateOrderStatus, orderSelected, handleState])
+
     const handleMessageNewOrder = useCallback((event: MessageEvent) => {
         try {
             const order: Order = JSON.parse(event.data);
@@ -119,7 +126,7 @@ export function OrdersTracking() {
                             handleOrderDeselected: () => handleState(null),
                             tableFilter,
                             handleTableFilterChange,
-                            updateOrderStatus,
+                            updateOrderStatus: updateOrderAndSelectionStatus,
                             sorting,
                             handleSortingChange
                         }}>


### PR DESCRIPTION
## Summary
- update order tracking page to sync selected order status

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861e7023a648333b0568dbd55920f21