### PR TITLE
Add docs about team page gaps

### DIFF
--- a/docs/equipe-backend-missing.md
+++ b/docs/equipe-backend-missing.md
@@ -1,0 +1,9 @@
+# Backend Endpoints Missing for Equipe Page
+
+The current implementation of the dashboard's team page relies on several API calls defined under `src/api/endpoints`. The following additional endpoints would be needed to fully implement all features:
+
+- **Bulk member updates** – endpoints to activate/deactivate multiple memberships and to export member lists are not present.
+- **Edit member details** – an endpoint to update another user's profile (name, phone, etc.) should be exposed so the edit dialog can save changes.
+- **Team statistics** – a summary endpoint could provide counts of active, pending and inactive members instead of computing on the client.
+- **Invitation email** – if invitations should be sent by email, a backend route would be required to dispatch the email after `createInvitation`.
+

--- a/docs/equipe-page-status.md
+++ b/docs/equipe-page-status.md
@@ -1,0 +1,12 @@
+# Equipe Page Current Status
+
+This document lists missing or incomplete features in `src/pages/dashboard/staff.tsx` ("Equipe" page).
+
+## Missing or incomplete behaviours
+
+- **Bulk actions have no backend logic** – `handleBulkAction` in `dashboard-staff-context.tsx` only shows a toast and clears selections without making API calls.
+- **Member editing dialog not implemented** – `handleEditMember` sets `isEditDialogOpen` but the page never renders a dialog to update member info.
+- **View permissions button on mobile cards lacks action** – the "Ver Permissões" option in `member-card.tsx` does nothing when clicked.
+- **View mode toggle unused** – `Filters` component allows switching between table and cards but `staff.tsx` never uses `viewMode` state.
+- **Stats derived from client data** – totals for active, pending and inactive members are computed locally; there is no endpoint to retrieve these counts directly.
+


### PR DESCRIPTION
## Summary
- add overview of missing features on the Equipe page
- document which backend endpoints are still needed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863d1aac1d483338e54101f159fddd4