### PR TITLE
Fix view mode and member card actions

### DIFF
--- a/src/components/pages/dashboard-staff/member-row.tsx
+++ b/src/components/pages/dashboard-staff/member-row.tsx
@@ -28,6 +28,12 @@ import { Clock, Edit, Eye, Mail, MoreHorizontal, Phone, Trash2 } from "lucide-re
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Badge } from "@/components/ui/badge"
 import { getSectionLabel } from "@/lib/helpers/section-label"
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip"
 
 interface MemberRowProps {
     user: User
@@ -43,7 +49,7 @@ export default function MemberRow({ user }: MemberRowProps) {
         updateMemberRole,
     } = useDashboardStaff()
 
-    const { restaurant } = useDashboardContext()
+    const { restaurant, user: currentUser } = useDashboardContext()
     const { data: roles } = useListRestaurantRoles(restaurant._id)
     const filteredRoles = (roles ?? []).filter(r => r.name !== "no_role")
 
@@ -77,7 +83,18 @@ export default function MemberRow({ user }: MemberRowProps) {
                             </AvatarFallback>
                         </Avatar>
                         <div>
-                            <div className="font-medium">{`${user.firstName} ${user.lastName}`}</div>
+                            <TooltipProvider>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <div className="font-medium">
+                                            {user._id === currentUser._id ? "Eu" : `${user.firstName} ${user.lastName}`}
+                                        </div>
+                                    </TooltipTrigger>
+                                    {user._id === currentUser._id && (
+                                        <TooltipContent>{`${user.firstName} ${user.lastName}`}</TooltipContent>
+                                    )}
+                                </Tooltip>
+                            </TooltipProvider>
                             <div className="text-sm text-gray-500">{user.email}</div>
                         </div>
                     </div>
@@ -137,7 +154,11 @@ export default function MemberRow({ user }: MemberRowProps) {
                                 Ver Permissões
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
-                            <DropdownMenuItem className="text-red-600" onClick={() => handleDeleteMember(user)}>
+                            <DropdownMenuItem
+                                className="text-red-600"
+                                onClick={() => handleDeleteMember(user)}
+                                disabled={user._id === currentUser._id}
+                            >
                                 <Trash2 className="w-4 h-4 mr-2" />
                                 Remover
                             </DropdownMenuItem>

--- a/src/pages/dashboard/staff.tsx
+++ b/src/pages/dashboard/staff.tsx
@@ -24,7 +24,6 @@ import { InvitationsTable } from "@/components/pages/dashboard-staff/invitations
 import { DashboardStaffProvider, useDashboardStaff } from "@/context/dashboard-staff-context"
 import { Stats } from "@/components/pages/dashboard-staff/stats"
 import { Filters } from "@/components/pages/dashboard-staff/filters"
-import { BulkActions } from "@/components/pages/dashboard-staff/bulk-actions"
 import { MembersTable } from "@/components/pages/dashboard-staff/members-table"
 import { MemberCard } from "@/components/pages/dashboard-staff/member-card"
 import { Pagination } from "@/components/pages/dashboard-staff/pagination"
@@ -122,6 +121,8 @@ function StaffContent() {
         sortDirection,
         currentPage,
         itemsPerPage,
+        viewMode,
+        setViewMode,
         inviteForm,
         setInviteForm,
         roleForm,
@@ -698,7 +699,6 @@ function StaffContent() {
                     </div>
 
                     <Filters />
-                    <BulkActions />
 
                     <Card>
                         <CardHeader>
@@ -710,20 +710,15 @@ function StaffContent() {
                             </div>
                         </CardHeader>
                         <CardContent>
-                            {/* Desktop Table View */}
-                            <div className="hidden lg:block">
+                            {viewMode === "table" ? (
                                 <MembersTable />
-                            </div>
-
-                            {/* Mobile Cards View */}
-                            <div className="lg:hidden space-y-4">
-                                {paginatedMembers.map((member: User) => (
-                                    <MemberCard 
-                                        key={member._id} 
-                                        member={member}
-                                    />
-                                ))}
-                            </div>
+                            ) : (
+                                <div className="space-y-4">
+                                    {paginatedMembers.map((member: User) => (
+                                        <MemberCard key={member._id} member={member} />
+                                    ))}
+                                </div>
+                            )}
 
                             <Pagination />
                         </CardContent>


### PR DESCRIPTION
## Summary
- remove unused bulk actions from staff page
- allow switching between table and card views using viewMode
- show permissions from mobile member cards
- display current user as "Eu" with tooltip and prevent self removal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6863d7f319a48333bdf6375d71caf86a