### PR TITLE
Improve dashboard staff responsiveness

### DIFF
--- a/src/components/pages/dashboard-staff/filters.tsx
+++ b/src/components/pages/dashboard-staff/filters.tsx
@@ -28,19 +28,11 @@ export function Filters() {
                         <Button
                             variant={viewMode === "table" ? "default" : "outline"}
                             size="sm"
-                            onClick={() => setViewMode("table")}
+                            onClick={() => setViewMode(viewMode === "table" ? "cards" : "table")}
                             className="hidden lg:flex"
                         >
                             <BarChart3 className="w-4 h-4 mr-2" />
                             Tabela
-                        </Button>
-                        <Button
-                            variant={viewMode === "cards" ? "default" : "outline"}
-                            size="sm"
-                            onClick={() => setViewMode("cards")}
-                            className="lg:hidden"
-                        >
-                            Cards
                         </Button>
                     </div>
                 </div>

--- a/src/components/pages/dashboard-staff/invitation-card.tsx
+++ b/src/components/pages/dashboard-staff/invitation-card.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react"
+import { format } from "date-fns"
+import { ptBR } from "date-fns/locale"
+import { useQueryClient } from "@tanstack/react-query"
+import { Copy, Trash2 } from "lucide-react"
+
+import { Invitation } from "@/types/invitation"
+import { useGetRole } from "@/api/endpoints/role/hook"
+import { invitationApi } from "@/api/endpoints/invitation/requests"
+import { copyToClipboard } from "@/lib/helpers/copy-to-clipboard"
+import { showPromiseToast, showSuccessToast } from "@/utils/notifications/toast"
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+export function InvitationCard({ invitation }: { invitation: Invitation }) {
+    const [open, setOpen] = useState(false)
+    const queryClient = useQueryClient()
+    const link = `www.neemble-eat.com/invitation/${invitation._id}`
+
+    const handleDelete = () => {
+        showPromiseToast(
+            invitationApi.deleteInvitation(invitation._id).then(() => {
+                queryClient.invalidateQueries({ queryKey: ["invitations", invitation.restaurantId] })
+            }),
+            {
+                loading: "Cancelando convite...",
+                success: "Convite cancelado!",
+                error: "Erro ao cancelar convite."
+            }
+        )
+    }
+
+    const handleCopy = () => {
+        copyToClipboard(link)
+        showSuccessToast("Link copiado!")
+    }
+
+    const { data: role } = useGetRole(invitation.roleId)
+    const roleName = role?.name === "no_role" ? "Sem função" : role?.name ?? "Carregando..."
+
+    return (
+        <Card className="p-4 space-y-1">
+            <div className="flex items-start justify-between">
+                <div className="font-medium">{invitation.name}</div>
+                <div className="flex gap-2">
+                    <Button variant="ghost" size="sm" onClick={handleCopy}>
+                        <Copy className="w-4 h-4" />
+                    </Button>
+                    <AlertDialog open={open} onOpenChange={setOpen}>
+                        <AlertDialogTrigger asChild>
+                            <Button variant="ghost" size="sm" className="text-red-600">
+                                <Trash2 className="w-4 h-4" />
+                            </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                            <AlertDialogHeader>
+                                <AlertDialogTitle>Cancelar convite</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                    Tem a certeza que deseja cancelar este convite?
+                                </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                                <AlertDialogCancel>Não</AlertDialogCancel>
+                                <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
+                                    Sim
+                                </AlertDialogAction>
+                            </AlertDialogFooter>
+                        </AlertDialogContent>
+                    </AlertDialog>
+                </div>
+            </div>
+            <div className="text-sm text-gray-500">{roleName}</div>
+            <div className="text-sm">
+                {format(new Date(invitation.createdAt), "dd/MM/yyyy", { locale: ptBR })}
+            </div>
+        </Card>
+    )
+}

--- a/src/context/dashboard-staff-context.tsx
+++ b/src/context/dashboard-staff-context.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useState, ReactNode, JSX} from "react"
+import {createContext, useContext, useState, ReactNode, JSX, useEffect} from "react"
 import { User } from "@/types/user"
 import { Role, RoleCreate, SectionPermission } from "@/types/role"
 import { InvitationCreate } from "@/types/invitation"
@@ -9,6 +9,7 @@ import { showSuccessToast, showErrorToast } from "@/utils/notifications/toast"
 import { useUpdateMemberRole } from "@/api/endpoints/memberships/hooks"
 import { Badge } from "@/components/ui/badge"
 import { restaurantApi } from "@/api/endpoints/restaurants/requests"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 type SortableUserFields = keyof Pick<User, 'firstName' | 'lastName' | 'email' | 'isActive' | 'updatedAt'>
 
@@ -70,6 +71,7 @@ interface DashboardStaffContextType {
 const DashboardStaffContext = createContext<DashboardStaffContextType | undefined>(undefined)
 
 export function DashboardStaffProvider({ children }: { children: ReactNode }) {
+    const isMobile = useIsMobile()
     const [searchTerm, setSearchTerm] = useState("")
     const [statusFilter, setStatusFilter] = useState("todos")
     const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false)
@@ -81,7 +83,11 @@ export function DashboardStaffProvider({ children }: { children: ReactNode }) {
     const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc")
     const [currentPage, setCurrentPage] = useState(1)
     const [itemsPerPage] = useState(10)
-    const [viewMode, setViewMode] = useState<"table" | "cards">("table")
+    const [viewMode, setViewMode] = useState<"table" | "cards">(isMobile ? "cards" : "table")
+
+    useEffect(() => {
+        if (isMobile) setViewMode("cards")
+    }, [isMobile])
     const [editingRole, setEditingRole] = useState<Role | null>(null)
     const [isEditRoleDialogOpen, setIsEditRoleDialogOpen] = useState(false)
 

--- a/src/pages/dashboard/staff.tsx
+++ b/src/pages/dashboard/staff.tsx
@@ -21,6 +21,7 @@ import { showSuccessToast, showErrorToast, showPromiseToast } from "@/utils/noti
 import { invitationApi } from "@/api/endpoints/invitation/requests"
 import { useGetRestaurantInvitations } from "@/hooks/use-get-restaurant-invitations"
 import { InvitationsTable } from "@/components/pages/dashboard-staff/invitations-table"
+import { InvitationCard } from "@/components/pages/dashboard-staff/invitation-card"
 import { DashboardStaffProvider, useDashboardStaff } from "@/context/dashboard-staff-context"
 import { Stats } from "@/components/pages/dashboard-staff/stats"
 import { Filters } from "@/components/pages/dashboard-staff/filters"
@@ -30,6 +31,7 @@ import { Pagination } from "@/components/pages/dashboard-staff/pagination"
 import { useGetAllMembers } from "@/hooks/use-get-all-members"
 import { useListRestaurantRoles } from "@/hooks/use-list-restaurant-roles"
 import { useDashboardContext } from "@/context/dashboard-context"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { copyToClipboard } from "@/lib/helpers/copy-to-clipboard"
 import {
     Dialog,
@@ -137,6 +139,8 @@ function StaffContent() {
         setIsEditRoleDialogOpen,
 
     } = useDashboardStaff()
+
+    const isMobile = useIsMobile()
 
 
     const { restaurant, user } = useDashboardContext()
@@ -710,7 +714,7 @@ function StaffContent() {
                             </div>
                         </CardHeader>
                         <CardContent>
-                            {viewMode === "table" ? (
+                            {viewMode === "table" && !isMobile ? (
                                 <MembersTable />
                             ) : (
                                 <div className="space-y-4">
@@ -734,7 +738,15 @@ function StaffContent() {
                             </div>
                         </CardHeader>
                         <CardContent>
-                            <InvitationsTable invitations={invitations} />
+                            {viewMode === "table" && !isMobile ? (
+                                <InvitationsTable invitations={invitations} />
+                            ) : (
+                                <div className="space-y-4">
+                                    {invitations.map((inv) => (
+                                        <InvitationCard key={inv._id} invitation={inv} />
+                                    ))}
+                                </div>
+                            )}
                         </CardContent>
                     </Card>
                 </div>


### PR DESCRIPTION
## Summary
- enable auto card view on mobile for team management
- add InvitationCard component and use on small screens
- toggle table view with 'Tabela' button on desktops

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863de4bd3988333b3612520d317fe3f