### PR TITLE
Fix menu overview and categories table

### DIFF
--- a/src/api/endpoints/categories/hooks.ts
+++ b/src/api/endpoints/categories/hooks.ts
@@ -83,13 +83,14 @@ export function useGetCategoryBySlug(categorySlug: string){
 }
 
 
-export function useGetCategoryItems(categoryId: string){
+export function useGetCategoryItems(categoryId?: string){
 
-    const queryKey = ["category slug", categoryId]
+    const queryKey = ["category items", categoryId]
 
     return useQuery({
         queryKey,
-        queryFn: () => categoryApi.getCategoryItems(categoryId),
+        queryFn: () => categoryApi.getCategoryItems(categoryId!),
+        enabled: !!categoryId,
     })
 
 }

--- a/src/components/pages/dashboard-menu/overview-tab.tsx
+++ b/src/components/pages/dashboard-menu/overview-tab.tsx
@@ -159,51 +159,6 @@ export function OverviewTab({ menu, onUpdate, isUpdating = false }: OverviewTabP
                     </div>
                 </CardContent>
             </Card>
-
-            {/* Preferências de Exibição */}
-            <Card className="hidden">
-                <CardHeader>
-                    <CardTitle>Preferências de Exibição</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                    <div className="flex items-center justify-between">
-                        <div className="space-y-0.5">
-                            <Label>Destaque os Itens em Destaque</Label>
-                            <p className="text-sm text-gray-500">Mostrar itens em destaque de forma proeminente no cardápio</p>
-                        </div>
-                        <Switch
-                            checked={menu.preferences.highlightFeaturedItems}
-                            onCheckedChange={(checked) => handlePreferenceChange("highlightFeaturedItems", checked)}
-                            disabled={isUpdating}
-                        />
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                        <div className="space-y-0.5">
-                            <Label>Mostrar Preços</Label>
-                            <p className="text-sm text-gray-500">Exibir os preços dos itens para os clientes</p>
-                        </div>
-                        <Switch
-                            checked={menu.preferences.showPrices}
-                            onCheckedChange={(checked) => handlePreferenceChange("showPrices", checked)}
-                            disabled={isUpdating}
-                        />
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                        <div className="space-y-0.5">
-                            <Label>Mostrar Imagens dos Itens</Label>
-                            <p className="text-sm text-gray-500">Exibir imagens para os itens do cardápio</p>
-                        </div>
-                        <Switch
-                            checked={menu.preferences.showItemImages}
-                            onCheckedChange={(checked) => handlePreferenceChange("showItemImages", checked)}
-                            disabled={isUpdating}
-                        />
-                    </div>
-                </CardContent>
-            </Card>
-
             {/* Estatísticas do Cardápio */}
             <Card className="bg-white shadow-sm rounded-xl border border-gray-200">
                 <CardHeader className="border-b border-gray-100">

--- a/src/pages/dashboard/menu/menu.tsx
+++ b/src/pages/dashboard/menu/menu.tsx
@@ -118,10 +118,6 @@ export default function MenuManagementPage() {
                             </div>
                         </div>
                         <div className="flex items-center gap-2">
-                            <Button variant="outline" size="sm">
-                                <Eye className="h-4 w-4 mr-2" />
-                                Visualizar cardápio
-                            </Button>
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <Button size="sm" disabled={isPublishDisabled} onClick={handlePublishMenu}>


### PR DESCRIPTION
## Summary
- remove unused preview button
- trim obsolete display preferences card
- show actual items in category table
- support optional categoryId in hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865cd9eedc88333b57b763b0f7047b5