### PR TITLE
Add tooltip help to item forms

### DIFF
--- a/src/pages/dashboard/menu/items/create-item.tsx
+++ b/src/pages/dashboard/menu/items/create-item.tsx
@@ -1,13 +1,14 @@
 import type React from "react"
 
 import { useState } from "react"
-import { ArrowLeft, Upload, Plus, Trash2, X } from "lucide-react"
+import { ArrowLeft, Upload, Plus, Trash2, X, Info } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { Switch } from "@/components/ui/switch"
 import { Separator } from "@/components/ui/separator"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -423,7 +424,19 @@ export default function CreateItemPage() {
                                         </div>
 
                                         <div className="space-y-2">
-                                            <Label>Tipo de Limite</Label>
+                                            <div className="flex items-center gap-1">
+                                                <Label>Tipo de Limite</Label>
+                                                <TooltipProvider>
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <Info className="h-4 w-4 text-muted-foreground" />
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>
+                                                            Define como o cliente pode selecionar as opções. Exemplo: "Até" permite escolher até o limite definido.
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                </TooltipProvider>
+                                            </div>
                                             <Select
                                                 value={customization.limitType}
                                                 onValueChange={(value) => updateCustomization(customIndex, "limitType", value as LimitType)}
@@ -445,7 +458,19 @@ export default function CreateItemPage() {
                                         </div>
 
                                         <div className="space-y-2">
-                                            <Label>Limite</Label>
+                                            <div className="flex items-center gap-1">
+                                                <Label>Limite</Label>
+                                                <TooltipProvider>
+                                                    <Tooltip>
+                                                        <TooltipTrigger asChild>
+                                                            <Info className="h-4 w-4 text-muted-foreground" />
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>
+                                                            Número de opções permitidas segundo o tipo de limite selecionado.
+                                                        </TooltipContent>
+                                                    </Tooltip>
+                                                </TooltipProvider>
+                                            </div>
                                             <Input
                                                 type="number"
                                                 min="1"
@@ -510,7 +535,19 @@ export default function CreateItemPage() {
                                                             </div>
 
                                                             <div className="space-y-1">
-                                                                <Label className="text-xs">Price Modifier</Label>
+                                                                <div className="flex items-center gap-1">
+                                                                    <Label className="text-xs">Price Modifier</Label>
+                                                                    <TooltipProvider>
+                                                                        <Tooltip>
+                                                                            <TooltipTrigger asChild>
+                                                                                <Info className="h-3 w-3 text-muted-foreground" />
+                                                                            </TooltipTrigger>
+                                                                            <TooltipContent>
+                                                                                Valor adicionado ao preço base quando esta opção é escolhida.
+                                                                            </TooltipContent>
+                                                                        </Tooltip>
+                                                                    </TooltipProvider>
+                                                                </div>
                                                                 <Input
                                                                     type="number"
                                                                     step="0.01"
@@ -528,7 +565,19 @@ export default function CreateItemPage() {
                                                             </div>
 
                                                             <div className="space-y-1">
-                                                                <Label className="text-xs">Max Quantity *</Label>
+                                                                <div className="flex items-center gap-1">
+                                                                    <Label className="text-xs">Max Quantity *</Label>
+                                                                    <TooltipProvider>
+                                                                        <Tooltip>
+                                                                            <TooltipTrigger asChild>
+                                                                                <Info className="h-3 w-3 text-muted-foreground" />
+                                                                            </TooltipTrigger>
+                                                                            <TooltipContent>
+                                                                                Limite máximo que o cliente pode escolher desta opção.
+                                                                            </TooltipContent>
+                                                                        </Tooltip>
+                                                                    </TooltipProvider>
+                                                                </div>
                                                                 <Input
                                                                     type="number"
                                                                     min="1"

--- a/src/pages/dashboard/menu/items/item.tsx
+++ b/src/pages/dashboard/menu/items/item.tsx
@@ -1,6 +1,6 @@
 import type React from "react"
 import { useState, useEffect } from "react"
-import { ArrowLeft, Edit2, Save, X, Upload, Plus, Trash2, DollarSign, Settings } from "lucide-react"
+import { ArrowLeft, Edit2, Save, X, Upload, Plus, Trash2, DollarSign, Settings, Info } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { CustomizationOption, CustomizationRule, Item, LimitType, PartialItem } from "@/types/item"
 import { Link, useParams } from "react-router"
@@ -672,7 +673,19 @@ export default function ItemDetailsPage() {
                                                     </div>
 
                                                     <div className="space-y-2">
-                                                        <Label>Limit Type</Label>
+                                                        <div className="flex items-center gap-1">
+                                                            <Label>Limit Type</Label>
+                                                            <TooltipProvider>
+                                                                <Tooltip>
+                                                                    <TooltipTrigger asChild>
+                                                                        <Info className="h-4 w-4 text-muted-foreground" />
+                                                                    </TooltipTrigger>
+                                                                    <TooltipContent>
+                                                                        Define how customers can choose options. Example: "Up To" allows selecting up to the limit value.
+                                                                    </TooltipContent>
+                                                                </Tooltip>
+                                                            </TooltipProvider>
+                                                        </div>
                                                         <Select
                                                             value={customization.limitType}
                                                             onValueChange={(value) =>
@@ -696,7 +709,19 @@ export default function ItemDetailsPage() {
                                                     </div>
 
                                                     <div className="space-y-2">
-                                                        <Label>Limit</Label>
+                                                        <div className="flex items-center gap-1">
+                                                            <Label>Limit</Label>
+                                                            <TooltipProvider>
+                                                                <Tooltip>
+                                                                    <TooltipTrigger asChild>
+                                                                        <Info className="h-4 w-4 text-muted-foreground" />
+                                                                    </TooltipTrigger>
+                                                                    <TooltipContent>
+                                                                        Quantidade permitida conforme o tipo de limite selecionado.
+                                                                    </TooltipContent>
+                                                                </Tooltip>
+                                                            </TooltipProvider>
+                                                        </div>
                                                         <Input
                                                             type="number"
                                                             min="1"
@@ -739,7 +764,19 @@ export default function ItemDetailsPage() {
                                                                         </div>
 
                                                                         <div className="space-y-1">
-                                                                            <Label className="text-xs">Price Modifier</Label>
+                                                                            <div className="flex items-center gap-1">
+                                                                                <Label className="text-xs">Price Modifier</Label>
+                                                                                <TooltipProvider>
+                                                                                    <Tooltip>
+                                                                                        <TooltipTrigger asChild>
+                                                                                            <Info className="h-3 w-3 text-muted-foreground" />
+                                                                                        </TooltipTrigger>
+                                                                                        <TooltipContent>
+                                                                                            Valor extra somado ao preço do item quando selecionado.
+                                                                                        </TooltipContent>
+                                                                                    </Tooltip>
+                                                                                </TooltipProvider>
+                                                                            </div>
                                                                             <div className="relative">
                                                                                 <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-3 w-3" />
                                                                                 <Input
@@ -761,7 +798,19 @@ export default function ItemDetailsPage() {
                                                                         </div>
 
                                                                         <div className="space-y-1">
-                                                                            <Label className="text-xs">Max Quantity</Label>
+                                                                            <div className="flex items-center gap-1">
+                                                                                <Label className="text-xs">Max Quantity</Label>
+                                                                                <TooltipProvider>
+                                                                                    <Tooltip>
+                                                                                        <TooltipTrigger asChild>
+                                                                                            <Info className="h-3 w-3 text-muted-foreground" />
+                                                                                        </TooltipTrigger>
+                                                                                        <TooltipContent>
+                                                                                            Máximo permitido que o cliente pode selecionar desta opção.
+                                                                                        </TooltipContent>
+                                                                                    </Tooltip>
+                                                                                </TooltipProvider>
+                                                                            </div>
                                                                             <Input
                                                                                 type="number"
                                                                                 min="1"


### PR DESCRIPTION
## Summary
- provide info icons with tooltips on the item creation page
- provide info icons with tooltips on the item edit page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866f95fba2083338f4ab423f454053d