### PR TITLE
Fix customization deletion for unsaved entries

### DIFF
--- a/src/pages/dashboard/menu/items/create-item.tsx
+++ b/src/pages/dashboard/menu/items/create-item.tsx
@@ -98,6 +98,18 @@ export default function CreateItemPage() {
     }
 
     const removeCustomization = (index: number) => {
+        const customization: any = formData.customizations[index]
+        const isPersisted = customization && customization._id
+
+        if (!isPersisted) {
+            setFormData((prev) => ({
+                ...prev,
+                customizations: prev.customizations.filter((_, i) => i !== index),
+            }))
+            return
+        }
+
+        // Customizations are local during creation, so there's no persisted case
         setFormData((prev) => ({
             ...prev,
             customizations: prev.customizations.filter((_, i) => i !== index),

--- a/src/pages/dashboard/menu/items/item.tsx
+++ b/src/pages/dashboard/menu/items/item.tsx
@@ -189,6 +189,15 @@ export default function ItemDetailsPage() {
 
     const handleRemoveCustomization = async (index: number) => {
         if (!item) return
+
+        const isPersisted = index < item.customizations.length
+
+        if (!isPersisted) {
+            setCustomizations((prev) => prev.filter((_, i) => i !== index))
+            setCustomizationsDirty(true)
+            return
+        }
+
         try {
             await deleteCustomization.mutateAsync({ itemId: item._id, index })
             setCustomizations((prev) => prev.filter((_, i) => i !== index))


### PR DESCRIPTION
## Summary
- avoid calling the delete endpoint for unsaved customizations
- add the same check to the item creation page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866fe4fcfc08333a46fdbeb13848476