### PR TITLE
Connect onboarding user check to backend

### DIFF
--- a/docs/dashboard-missing-features.md
+++ b/docs/dashboard-missing-features.md
@@ -15,7 +15,7 @@ This document records UI elements and logic still missing in the dashboard codeb
 - Editing a member (`handleEditMember`) opens a dialog but the form submission to update the user is absent.
 
 ## Onboarding
-- `userExists` in `src/pages/root/onboarding.tsx` is a mock function and does not check the backend.
+<!-- userExists now checks the backend -->
 
 ## Layout
 - `DashboardLayout` falls back to a `dummyRestaurant` object when no restaurant is returned from the API.

--- a/src/pages/root/onboarding.tsx
+++ b/src/pages/root/onboarding.tsx
@@ -7,15 +7,20 @@ import {DataConfirmationStep} from "@/components/pages/onboarding/data-confirmat
 import { OnboardingLayout } from "@/components/layout/onboarding/onboarding-layout";
 import {User} from "@/types/user";
 import {Navigate, useNavigate} from "react-router";
-import {authApi} from "@/api/endpoints/auth/endpoints";
 import {toast} from "sonner";
 import {OnboardingContext} from "@/context/onboarding-context";
 import {useAuth} from "@/context/auth-context";
+import {userApi} from "@/api/endpoints/user/endpoints";
+import {authApi} from "@/api/endpoints/auth/endpoints";
 
-// Mock function to check if user exists - replace with your actual implementation
+// Check if the authenticated user already has a profile in the backend
 async function userExists(): Promise<{ exists: boolean; userData?: User }> {
-    // This is a mock implementation - replace with your actual API call
-    return { exists: false };
+    const exists = await userApi.userExists()
+    if (exists) {
+        const userData = await authApi.me()
+        return { exists: true, userData }
+    }
+    return { exists: false }
 }
 
 export default function OnboardingPage() {


### PR DESCRIPTION
## Summary
- check user existence using `userApi.userExists` and load profile via `authApi.me`
- note in docs that onboarding now uses backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68671baa18048333812a0a2e60faf608