### PR TITLE
Adapt SalesChart for mobile view

### DIFF
--- a/src/components/pages/dashboard-home/sales-chart.tsx
+++ b/src/components/pages/dashboard-home/sales-chart.tsx
@@ -1,9 +1,11 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 export default function SalesChart() {
     const { lastSevenDaysOrdersCount, isLastSevenDaysOrdersCountLoading } = useDashboardHomeContext()
+    const isMobile = useIsMobile()
 
     const dayMap: Record<string, string> = {
         monday: "Seg",
@@ -34,29 +36,40 @@ export default function SalesChart() {
                         <span className="text-sm text-muted-foreground">Sem dados disponíveis</span>
                     </div>
                 ) : (
-                    <div className="h-[200px] flex items-end justify-between space-x-2">
-                        {salesData.map(data => (
-                            <TooltipProvider key={data.date}>
-                                <Tooltip>
-                                    <TooltipTrigger className="w-full">
-                                        <div className="flex flex-col items-center space-y-2 flex-1">
-                                            <div
-                                                className="bg-primary rounded-t transition-all duration-500 hover:bg-primary/80 w-full"
-                                                style={{ height: `${(data.sales / maxSales) * 160}px` }}
-                                            />
-                                            <div className="flex flex-col items-center space-y-1">
-                                                <span className="text-xs text-muted-foreground">{dayMap[data.day] ?? data.day}</span>
-                                                <span className="text-xs text-muted-foreground">{`${data.date.slice(8, 10)}/${data.date.slice(5, 7)}/${data.date.slice(0, 4)}`}</span>
+                    isMobile ? (
+                        <ul className="space-y-2">
+                            {salesData.map(data => (
+                                <li key={data.date} className="flex items-center justify-between text-sm">
+                                    <span>{dayMap[data.day] ?? data.day} ({`${data.date.slice(8, 10)}/${data.date.slice(5, 7)}`})</span>
+                                    <span className="font-medium">{data.sales} pedidos</span>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <div className="h-[200px] flex items-end justify-between space-x-2">
+                            {salesData.map(data => (
+                                <TooltipProvider key={data.date}>
+                                    <Tooltip>
+                                        <TooltipTrigger className="w-full">
+                                            <div className="flex flex-col items-center space-y-2 flex-1">
+                                                <div
+                                                    className="bg-primary rounded-t transition-all duration-500 hover:bg-primary/80 w-full"
+                                                    style={{ height: `${(data.sales / maxSales) * 160}px` }}
+                                                />
+                                                <div className="flex flex-col items-center space-y-1">
+                                                    <span className="text-xs text-muted-foreground">{dayMap[data.day] ?? data.day}</span>
+                                                    <span className="text-xs text-muted-foreground">{`${data.date.slice(8, 10)}/${data.date.slice(5, 7)}/${data.date.slice(0, 4)}`}</span>
+                                                </div>
                                             </div>
-                                        </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        <span>{data.sales} pedidos</span>
-                                    </TooltipContent>
-                                </Tooltip>
-                            </TooltipProvider>
-                        ))}
-                    </div>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            <span>{data.sales} pedidos</span>
+                                        </TooltipContent>
+                                    </Tooltip>
+                                </TooltipProvider>
+                            ))}
+                        </div>
+                    )
                 )}
             </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- switch SalesChart to mobile-friendly list when screen is small
- keep bar chart for desktop screens
- keep weekday names in Portuguese

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867242666a48333a2558dd958aee1be