### PR TITLE
Fix type for customization removal

### DIFF
--- a/src/pages/dashboard/menu/items/create-item.tsx
+++ b/src/pages/dashboard/menu/items/create-item.tsx
@@ -98,8 +98,8 @@ export default function CreateItemPage() {
     }
 
     const removeCustomization = (index: number) => {
-        const customization: any = formData.customizations[index]
-        const isPersisted = customization && customization._id
+        const customization = formData.customizations[index]
+        const isPersisted = (customization as { _id?: string } | undefined)?._id
 
         if (!isPersisted) {
             setFormData((prev) => ({


### PR DESCRIPTION
## Summary
- correctly type `customization` when removing customizations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686729a577b883339cbdd0548d7fbbf5