### PR TITLE
Add custom date range filter

### DIFF
--- a/src/components/pages/dashboard-home/header.tsx
+++ b/src/components/pages/dashboard-home/header.tsx
@@ -1,17 +1,35 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Calendar, Filter } from "lucide-react"
+import { Calendar as CalendarIcon, Filter } from "lucide-react"
+import { useState } from "react"
+import { format } from "date-fns"
+import { pt } from "date-fns/locale"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Calendar } from "@/components/ui/calendar"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 import { DateFilter, ShiftFilter } from "@/types/dashboard"
 
 export default function DashboardHomeHeader() {
-    const { dateFilter, setDateFilter, shiftFilter, setShiftFilter } = useDashboardHomeContext()
+    const {
+        dateFilter,
+        setDateFilter,
+        customDateRange,
+        setCustomDateRange,
+        shiftFilter,
+        setShiftFilter,
+    } = useDashboardHomeContext()
+    const [isRangeOpen, setIsRangeOpen] = useState(false)
+
+    const rangeLabel = customDateRange.from && customDateRange.to
+        ? `${format(customDateRange.from, "dd/MM/yyyy", { locale: pt })} - ${format(customDateRange.to, "dd/MM/yyyy", { locale: pt })}`
+        : "Selecionar período"
 
     return (
         <div className="flex flex-col space-y-4 md:flex-row md:items-center md:justify-between md:space-y-0">
             <div className="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2">
                 <Select value={dateFilter} onValueChange={(value: DateFilter) => setDateFilter(value)}>
                     <SelectTrigger className="w-full sm:w-48">
-                        <Calendar className="h-4 w-4 mr-2" />
+                        <CalendarIcon className="h-4 w-4 mr-2" />
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -19,8 +37,31 @@ export default function DashboardHomeHeader() {
                         <SelectItem value="yesterday">Ontem</SelectItem>
                         <SelectItem value="7days">Últimos 7 dias</SelectItem>
                         <SelectItem value="30days">Últimos 30 dias</SelectItem>
+                        <SelectItem value="custom">Personalizado</SelectItem>
                     </SelectContent>
                 </Select>
+                {dateFilter === "custom" && (
+                    <Popover open={isRangeOpen} onOpenChange={setIsRangeOpen}>
+                        <PopoverTrigger asChild>
+                            <Button variant="outline" className="w-full sm:w-52 justify-start text-left font-normal">
+                                <CalendarIcon className="mr-2 h-4 w-4" />
+                                {rangeLabel}
+                            </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start" side="bottom" sideOffset={4}>
+                            <div className="p-3 bg-background">
+                                <Calendar
+                                    mode="range"
+                                    numberOfMonths={2}
+                                    selected={customDateRange}
+                                    onSelect={(range) => setCustomDateRange(range ?? {})}
+                                    locale={pt}
+                                    className="rounded-md border"
+                                />
+                            </div>
+                        </PopoverContent>
+                    </Popover>
+                )}
                 <Select value={shiftFilter} onValueChange={(value: ShiftFilter) => setShiftFilter(value)}>
                     <SelectTrigger className="w-full sm:w-32">
                         <Filter className="h-4 w-4 mr-2" />

--- a/src/context/dashboard-home-context.ts
+++ b/src/context/dashboard-home-context.ts
@@ -14,6 +14,8 @@ import {
 export interface DashboardHomeContextProps {
     dateFilter: DateFilter
     setDateFilter: (filter: DateFilter) => void
+    customDateRange: { from?: Date; to?: Date }
+    setCustomDateRange: (range: { from?: Date; to?: Date }) => void
     shiftFilter: ShiftFilter
     setShiftFilter: (filter: ShiftFilter) => void
     itemsTimeRange: ItemsTimeRange

--- a/src/pages/dashboard/dashboard-home.tsx
+++ b/src/pages/dashboard/dashboard-home.tsx
@@ -68,6 +68,7 @@ const insights: Insight[] = [
 
 export default function RestaurantDashboard(): JSX.Element {
     const [dateFilter, setDateFilter] = useState<DateFilter>("7days")
+    const [customDateRange, setCustomDateRange] = useState<{ from?: Date; to?: Date }>({})
     const [shiftFilter, setShiftFilter] = useState<ShiftFilter>("all")
     const [itemsTimeRange, setItemsTimeRange] = useState<ItemsTimeRange>("today")
     const [isExporting, setIsExporting] = useState<boolean>(false)
@@ -77,7 +78,10 @@ export default function RestaurantDashboard(): JSX.Element {
     } = useDashboardContext()
 
     // Helper function to get date range from filter
-    const getDateRangeFromFilter = (filter: DateFilter | ItemsTimeRange) => {
+    const getDateRangeFromFilter = (
+        filter: DateFilter | ItemsTimeRange,
+        custom?: { from?: Date; to?: Date }
+    ) => {
         const today = new Date()
         const from = new Date()
 
@@ -99,6 +103,10 @@ export default function RestaurantDashboard(): JSX.Element {
             case "month":
                 from.setDate(today.getDate() - 30)
                 break
+            case "custom":
+                if (custom?.from) from.setTime(custom.from.getTime())
+                if (custom?.to) today.setTime(custom.to.getTime())
+                break
         }
 
         return {
@@ -107,7 +115,10 @@ export default function RestaurantDashboard(): JSX.Element {
         }
     }
 
-    const dateRange = useMemo(() => getDateRangeFromFilter(dateFilter), [dateFilter])
+    const dateRange = useMemo(
+        () => getDateRangeFromFilter(dateFilter, customDateRange),
+        [dateFilter, customDateRange]
+    )
     const itemsDateRange = useMemo(() => getDateRangeFromFilter(itemsTimeRange), [itemsTimeRange])
 
 
@@ -268,6 +279,8 @@ export default function RestaurantDashboard(): JSX.Element {
         <DashboardHomeContext.Provider value={{
             dateFilter,
             setDateFilter,
+            customDateRange,
+            setCustomDateRange,
             shiftFilter,
             setShiftFilter,
             itemsTimeRange,

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -58,7 +58,7 @@ export interface ExportData {
     shiftFilter: string
 }
 
-export type DateFilter = "today" | "yesterday" | "7days" | "30days"
+export type DateFilter = "today" | "yesterday" | "7days" | "30days" | "custom"
 export type ShiftFilter = "all" | "lunch" | "dinner"
 export type ItemsTimeRange = "today" | "week" | "month"
 export type MetricFormat = "currency" | "number" | "percentage"


### PR DESCRIPTION
## Summary
- extend `DateFilter` to support custom date ranges
- store custom date range in dashboard context
- allow choosing a custom range in dashboard home header
- adjust dashboard home to compute queries with the chosen range

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb6683b083339ea8a2682bd386a7