### PR TITLE
Fix missing date filter label

### DIFF
--- a/src/pages/dashboard/dashboard-home.tsx
+++ b/src/pages/dashboard/dashboard-home.tsx
@@ -174,6 +174,7 @@ export default function RestaurantDashboard(): JSX.Element {
             yesterday: "Ontem",
             "7days": "Últimos 7 dias",
             "30days": "Últimos 30 dias",
+            custom: "Personalizado",
         }
         return labels[filter]
     }, [])


### PR DESCRIPTION
## Summary
- add missing label for custom date filter

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_6867f8190a7883339888c2a16186aa44