### PR TITLE
Fix date range typing for Dashboard

### DIFF
--- a/src/components/pages/dashboard-home/header.tsx
+++ b/src/components/pages/dashboard-home/header.tsx
@@ -8,6 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Calendar } from "@/components/ui/calendar"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 import { DateFilter, ShiftFilter } from "@/types/dashboard"
+import type { DateRange } from "react-day-picker"
 
 export default function DashboardHomeHeader() {
     const {
@@ -20,7 +21,7 @@ export default function DashboardHomeHeader() {
     } = useDashboardHomeContext()
     const [isRangeOpen, setIsRangeOpen] = useState(false)
 
-    const rangeLabel = customDateRange.from && customDateRange.to
+    const rangeLabel = customDateRange?.from && customDateRange.to
         ? `${format(customDateRange.from, "dd/MM/yyyy", { locale: pt })} - ${format(customDateRange.to, "dd/MM/yyyy", { locale: pt })}`
         : "Selecionar período"
 
@@ -54,7 +55,7 @@ export default function DashboardHomeHeader() {
                                     mode="range"
                                     numberOfMonths={2}
                                     selected={customDateRange}
-                                    onSelect={(range) => setCustomDateRange(range ?? {})}
+                                    onSelect={(range: DateRange | undefined) => setCustomDateRange(range)}
                                     locale={pt}
                                     className="rounded-md border"
                                 />

--- a/src/context/dashboard-home-context.ts
+++ b/src/context/dashboard-home-context.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from "react"
 import { DateFilter, ItemsTimeRange, ShiftFilter, Insight } from "@/types/dashboard"
+import type { DateRange } from "react-day-picker"
 import {
     ActiveSessionCount,
     AverageSessionDuration,
@@ -14,8 +15,8 @@ import {
 export interface DashboardHomeContextProps {
     dateFilter: DateFilter
     setDateFilter: (filter: DateFilter) => void
-    customDateRange: { from?: Date; to?: Date }
-    setCustomDateRange: (range: { from?: Date; to?: Date }) => void
+    customDateRange: DateRange | undefined
+    setCustomDateRange: (range: DateRange | undefined) => void
     shiftFilter: ShiftFilter
     setShiftFilter: (filter: ShiftFilter) => void
     itemsTimeRange: ItemsTimeRange

--- a/src/pages/dashboard/dashboard-home.tsx
+++ b/src/pages/dashboard/dashboard-home.tsx
@@ -1,6 +1,7 @@
-import {JSX} from "react"
+import { JSX } from "react"
 
 import { useState, useCallback, useMemo } from "react"
+import type { DateRange } from "react-day-picker"
 import {
     DollarSign,
     Receipt,
@@ -68,7 +69,7 @@ const insights: Insight[] = [
 
 export default function RestaurantDashboard(): JSX.Element {
     const [dateFilter, setDateFilter] = useState<DateFilter>("7days")
-    const [customDateRange, setCustomDateRange] = useState<{ from?: Date; to?: Date }>({})
+    const [customDateRange, setCustomDateRange] = useState<DateRange | undefined>(undefined)
     const [shiftFilter, setShiftFilter] = useState<ShiftFilter>("all")
     const [itemsTimeRange, setItemsTimeRange] = useState<ItemsTimeRange>("today")
     const [isExporting, setIsExporting] = useState<boolean>(false)
@@ -80,7 +81,7 @@ export default function RestaurantDashboard(): JSX.Element {
     // Helper function to get date range from filter
     const getDateRangeFromFilter = (
         filter: DateFilter | ItemsTimeRange,
-        custom?: { from?: Date; to?: Date }
+        custom?: DateRange
     ) => {
         const today = new Date()
         const from = new Date()


### PR DESCRIPTION
## Summary
- adjust `DashboardHomeContext` types to use `DateRange`
- type `customDateRange` in `dashboard-home` and update helper signature
- update `DashboardHomeHeader` to handle optional ranges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6867fdb899ac8333943f23b2197dbe85