### PR TITLE
Add expiry date validation

### DIFF
--- a/src/pages/dashboard/stock.tsx
+++ b/src/pages/dashboard/stock.tsx
@@ -567,6 +567,16 @@ export default function StockManagement() {
             return
         }
 
+        if (newProduct.expiryDate) {
+            const today = new Date()
+            today.setHours(0, 0, 0, 0)
+            const expiry = new Date(newProduct.expiryDate)
+            if (expiry < today) {
+                showErrorToast("Erro", "A data de validade não pode ser anterior à data atual.")
+                return
+            }
+        }
+
         const data = {
             name: newProduct.name,
             unit: newProduct.unit,
@@ -1519,6 +1529,7 @@ export default function StockManagement() {
                                 <Input
                                     id="expiryDate"
                                     type="date"
+                                    min={getCurrentDate().toISOString().split("T")[0]}
                                     value={newProduct.expiryDate}
                                     onChange={(e) => setNewProduct({ ...newProduct, expiryDate: e.target.value })}
                                 />


### PR DESCRIPTION
## Summary
- prevent creating stock items with expiry date in the past
- require future expiry date via input control

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868309a116c8333b82c4917cfd04a39