### PR TITLE
Add grid view toggle for orders

### DIFF
--- a/src/components/pages/dashboard-orders/header.tsx
+++ b/src/components/pages/dashboard-orders/header.tsx
@@ -2,7 +2,7 @@ import {Button} from "@/components/ui/button";
 import {Select, SelectTrigger, SelectValue, SelectContent, SelectGroup, SelectItem} from "@/components/ui/select";
 import {Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger} from "@/components/ui/sheet";
 import {useState} from "react";
-import {SortAscending, SortDescending, ArrowRight} from "@phosphor-icons/react"
+import {SortAscending, SortDescending, ArrowRight, SquaresFour, List as ListIcon} from "@phosphor-icons/react"
 import {FILTERS, Tag} from "@/pages/dashboard/order-tracking";
 import type {OrderPrepStatus} from "@/types/order";
 import {useOrdersTrackingContext} from "@/context/orders-tracking-context";
@@ -17,7 +17,7 @@ export function Header({ customOrderUrl }: HeaderProps) {
 
     const isMobile = useIsMobile()
 
-    const { activeFilters, toggleFilter, clearFilters, orders, handleTableFilterChange, sorting, handleSortingChange} = useOrdersTrackingContext()
+    const { activeFilters, toggleFilter, clearFilters, orders, handleTableFilterChange, sorting, handleSortingChange, viewMode, setViewMode} = useOrdersTrackingContext()
     const [isSheetOpen, setIsSheetOpen] = useState<boolean>(false)
 
 
@@ -124,6 +124,11 @@ export function Header({ customOrderUrl }: HeaderProps) {
                                 </>
 
                             }
+                        </Button>
+                    </div>
+                    <div>
+                        <Button variant="secondary" className="hover:bg-zinc-200" onClick={() => setViewMode(viewMode === 'list' ? 'grid' : 'list')}>
+                            {viewMode === 'list' ? <SquaresFour/> : <ListIcon/>}
                         </Button>
                     </div>
                 </div>

--- a/src/components/pages/dashboard-orders/orders-display.tsx
+++ b/src/components/pages/dashboard-orders/orders-display.tsx
@@ -4,7 +4,7 @@ import {OrderListing} from "@/components/pages/dashboard-orders/order-listing";
 
 export function OrdersDisplay() {
 
-    const {orders, activeFilters, tableFilter, sorting} = useOrdersTrackingContext()
+    const {orders, activeFilters, tableFilter, sorting, viewMode} = useOrdersTrackingContext()
 
     const filteredOrders = orders.filter((order) => {
         const matchesFilterMode = activeFilters.length === 0 || activeFilters.includes(order.prepStatus);
@@ -22,7 +22,7 @@ export function OrdersDisplay() {
     });
 
     return (
-        <div className={`space-y-1.5 p-1`}>
+        <div className={`p-1 ${viewMode === 'grid' ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5' : 'space-y-1.5'}`}>
             {
                 filteredOrders.map(order => (
                     <OrderListing key={order._id} order={order}/>

--- a/src/context/orders-tracking-context.ts
+++ b/src/context/orders-tracking-context.ts
@@ -15,6 +15,8 @@ interface OrdersTrackingContextProps {
     updateOrderStatus: (orderId: string, newStatus: string) => void
     sorting: "asc" | "desc"
     handleSortingChange: (order: "asc" | "desc") => void
+    viewMode: "list" | "grid"
+    setViewMode: (mode: "list" | "grid") => void
 }
 
 export const OrdersTrackingContext = createContext<OrdersTrackingContextProps | undefined>(undefined)

--- a/src/pages/dashboard/order-tracking.tsx
+++ b/src/pages/dashboard/order-tracking.tsx
@@ -53,6 +53,7 @@ export function OrdersTracking() {
     const {state: tableFilter, handleState: handleTableFilterChange} = useSelectedState<string | null>(null)
     const {state: orderSelected, handleState} = useSelectedState<Order | null>(null)
     const {state: sorting, handleState: handleSortingChange} = useSelectedState<"asc" | "desc">("desc")
+    const {state: viewMode, handleState: setViewMode} = useSelectedState<"list" | "grid">("list")
 
     const { data: orders, addOrder, removeOrders, updateOrderStatus, isLoading } = useGetRecentOrders(restaurant._id)
 
@@ -128,7 +129,9 @@ export function OrdersTracking() {
                             handleTableFilterChange,
                             updateOrderStatus: updateOrderAndSelectionStatus,
                             sorting,
-                            handleSortingChange
+                            handleSortingChange,
+                            viewMode,
+                            setViewMode
                         }}>
                             <div className="lg:flex lg:flex-col flex-1">
                                 <div className="flex justify-between">


### PR DESCRIPTION
## Summary
- extend orders tracking context with `viewMode`
- implement grid/list toggle in dashboard orders header
- support grid layout in orders display

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68684c4f78c48333b90bf6652a694334