### PR TITLE
Add login option for restaurant invitations

### DIFF
--- a/src/components/pages/login/login-form.tsx
+++ b/src/components/pages/login/login-form.tsx
@@ -21,9 +21,10 @@ import {Eye, EyeClosed} from "@phosphor-icons/react";
 
 interface LoginFormProps extends React.ComponentPropsWithoutRef<"div"> {
     className?: string
+    onLoggedIn?: () => Promise<void> | void
 }
 
-export function LoginForm({ className, ...props }: LoginFormProps) {
+export function LoginForm({ className, onLoggedIn, ...props }: LoginFormProps) {
     const [isLoading, setIsLoading] = useState<boolean>(false)
 
     const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false)
@@ -58,7 +59,11 @@ export function LoginForm({ className, ...props }: LoginFormProps) {
                 toast.error("Deve completar o onboarding para poder continuar")
                 navigate("/onboarding")
             } else {
-                navigate("/dashboard")
+                if (onLoggedIn) {
+                    await onLoggedIn()
+                } else {
+                    navigate("/dashboard")
+                }
             }
         } catch (e: unknown) {
             const error = e as Error
@@ -85,7 +90,11 @@ export function LoginForm({ className, ...props }: LoginFormProps) {
                 toast.error("Deve completar o onboarding para poder continuar")
                 navigate("/onboarding")
             } else {
-                navigate("/dashboard")
+                if (onLoggedIn) {
+                    await onLoggedIn()
+                } else {
+                    navigate("/dashboard")
+                }
             }
         } catch (e: unknown) {
             const error = e as Error


### PR DESCRIPTION
## Summary
- extend `LoginForm` to support a callback after login
- add a new flow on the invitation page to choose between creating a new account or logging in
- when logging in from an invitation, automatically add and activate the membership

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68691bb770cc83339b5ace2c0b141a39