### PR TITLE
Add info tooltips to dashboard cards

### DIFF
--- a/src/components/pages/dashboard-home/export-buttons.tsx
+++ b/src/components/pages/dashboard-home/export-buttons.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Download, FileText } from "lucide-react"
+import { Download, FileText, Info } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 
 export default function ExportButtons() {
@@ -9,7 +10,17 @@ export default function ExportButtons() {
     return (
         <Card>
             <CardHeader>
-                <CardTitle>Exportar Dados</CardTitle>
+                <CardTitle className="flex items-center space-x-1">
+                    <span>Exportar Dados</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="cursor-default">
+                                <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Descarregue os dados do dashboard em diferentes formatos</TooltipContent>
+                    </Tooltip>
+                </CardTitle>
                 <CardDescription>Descarregue os dados do dashboard em diferentes formatos</CardDescription>
             </CardHeader>
             <CardContent>

--- a/src/components/pages/dashboard-home/insights-card.tsx
+++ b/src/components/pages/dashboard-home/insights-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Lightbulb } from "lucide-react"
+import { Lightbulb, Info } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 
 export default function InsightsCard() {
@@ -11,6 +12,14 @@ export default function InsightsCard() {
                 <CardTitle className="flex items-center space-x-2">
                     <Lightbulb className="h-5 w-5" />
                     <span>Insights com IA</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="cursor-default">
+                                <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Sugestões automatizadas baseadas nos seus dados</TooltipContent>
+                    </Tooltip>
                 </CardTitle>
                 <CardDescription>Sugestões automatizadas baseadas nos seus dados</CardDescription>
             </CardHeader>

--- a/src/components/pages/dashboard-home/metric-card.tsx
+++ b/src/components/pages/dashboard-home/metric-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { TrendingDown, TrendingUp } from "lucide-react"
+import { TrendingDown, TrendingUp, Info } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { MetricFormat } from "@/types/dashboard"
 
 interface MetricCardProps {
@@ -9,6 +10,7 @@ interface MetricCardProps {
     icon: React.ComponentType<{ className?: string }>
     format?: MetricFormat
     isLoading?: boolean
+    info?: string
 }
 
 function formatValue(val: number, format: MetricFormat): string {
@@ -22,7 +24,7 @@ function formatValue(val: number, format: MetricFormat): string {
     }
 }
 
-export default function MetricCard({ title, value, growth, icon: Icon, format = "currency", isLoading = false }: MetricCardProps) {
+export default function MetricCard({ title, value, growth, icon: Icon, format = "currency", isLoading = false, info }: MetricCardProps) {
     const isPositive = growth > 0
     const GrowthIcon = isPositive ? TrendingUp : TrendingDown
 
@@ -30,7 +32,19 @@ export default function MetricCard({ title, value, growth, icon: Icon, format = 
         <Card className="bg-zinc-100 py-0 flex flex-col">
             <Card className="flex-1 my-0 transition-all duration-300 hover:shadow-lg hover:scale-[1.02] shadow-sm">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+                    <CardTitle className="text-sm font-medium text-muted-foreground flex items-center space-x-1">
+                        <span>{title}</span>
+                        {info && (
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <span className="cursor-default">
+                                        <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                                    </span>
+                                </TooltipTrigger>
+                                <TooltipContent>{info}</TooltipContent>
+                            </Tooltip>
+                        )}
+                    </CardTitle>
                     <Icon className="h-4 w-4 text-purple-700"/>
                 </CardHeader>
                 <CardContent>

--- a/src/components/pages/dashboard-home/orders-chart.tsx
+++ b/src/components/pages/dashboard-home/orders-chart.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Info } from "lucide-react"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 
 export default function OrdersChart() {
@@ -21,7 +23,17 @@ export default function OrdersChart() {
     return (
         <Card>
             <CardHeader>
-                <CardTitle>Pedidos vs Cancelamentos</CardTitle>
+                <CardTitle className="flex items-center space-x-1">
+                    <span>Pedidos vs Cancelamentos</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="cursor-default">
+                                <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Comparação de pedidos realizados e cancelados</TooltipContent>
+                    </Tooltip>
+                </CardTitle>
                 <CardDescription>Comparação de pedidos realizados e cancelados</CardDescription>
             </CardHeader>
             <CardContent>

--- a/src/components/pages/dashboard-home/popular-items-chart.tsx
+++ b/src/components/pages/dashboard-home/popular-items-chart.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Progress } from "@/components/ui/progress"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { Info } from "lucide-react"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 import { ItemsTimeRange } from "@/types/dashboard"
 
@@ -16,7 +18,17 @@ export default function PopularItemsChart() {
         <Card>
             <CardHeader className="flex flex-row items-center justify-between">
                 <div>
-                    <CardTitle>Itens Mais Populares</CardTitle>
+                    <CardTitle className="flex items-center space-x-1">
+                        <span>Itens Mais Populares</span>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <span className="cursor-default">
+                                    <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                                </span>
+                            </TooltipTrigger>
+                            <TooltipContent>Pratos mais vendidos</TooltipContent>
+                        </Tooltip>
+                    </CardTitle>
                     <CardDescription>Pratos mais vendidos</CardDescription>
                 </div>
                 <Select value={itemsTimeRange} onValueChange={(v: ItemsTimeRange) => setItemsTimeRange(v)}>

--- a/src/components/pages/dashboard-home/sales-chart.tsx
+++ b/src/components/pages/dashboard-home/sales-chart.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Info } from "lucide-react"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 import { useIsMobile } from "@/hooks/use-mobile"
 
@@ -24,7 +25,17 @@ export default function SalesChart() {
     return (
         <Card className="col-span-full lg:col-span-2">
             <CardHeader>
-                <CardTitle>Evolução das Vendas</CardTitle>
+                <CardTitle className="flex items-center space-x-1 text-balance">
+                    <span>Evolução das Vendas</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="cursor-default">
+                                <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Vendas diárias dos últimos 7 dias</TooltipContent>
+                    </Tooltip>
+                </CardTitle>
                 <CardDescription>Vendas diárias dos últimos 7 dias</CardDescription>
             </CardHeader>
             <CardContent>

--- a/src/components/pages/dashboard-home/sessions-card.tsx
+++ b/src/components/pages/dashboard-home/sessions-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Clock, TrendingUp, Users } from "lucide-react"
+import { Clock, TrendingUp, Users, Info } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { useDashboardHomeContext } from "@/context/dashboard-home-context"
 
 export default function SessionsCard() {
@@ -15,7 +16,17 @@ export default function SessionsCard() {
     return (
         <Card>
             <CardHeader>
-                <CardTitle>Sessões de Cliente</CardTitle>
+                <CardTitle className="flex items-center space-x-1">
+                    <span>Sessões de Cliente</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="cursor-default">
+                                <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>Duração e atividade das sessões</TooltipContent>
+                    </Tooltip>
+                </CardTitle>
                 <CardDescription>Duração e atividade das sessões</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">

--- a/src/pages/dashboard/dashboard-home.tsx
+++ b/src/pages/dashboard/dashboard-home.tsx
@@ -319,6 +319,7 @@ export default function RestaurantDashboard(): JSX.Element {
                             icon={DollarSign}
                             format="currency"
                             isLoading={isSalesSummaryLoading}
+                            info="Somatório das vendas no período selecionado"
                         />
                         <MetricCard
                             title="Faturas Emitidas"
@@ -327,6 +328,7 @@ export default function RestaurantDashboard(): JSX.Element {
                             icon={Receipt}
                             format="number"
                             isLoading={isInvoiceSummaryLoading}
+                            info="Número de faturas geradas para os pedidos"
                         />
                         <MetricCard
                             title="Valor Médio por Fatura"
@@ -335,6 +337,7 @@ export default function RestaurantDashboard(): JSX.Element {
                             icon={ShoppingCart}
                             format="currency"
                             isLoading={isSalesSummaryLoading}
+                            info="Média de valor das faturas emitidas"
                         />
                         <MetricCard
                             title="Mesas Servidas"
@@ -343,6 +346,7 @@ export default function RestaurantDashboard(): JSX.Element {
                             icon={Users}
                             format="number"
                             isLoading={isSalesSummaryLoading}
+                            info="Quantidade de mesas atendidas"
                         />
                         <MetricCard
                             title="Receita por Mesa"
@@ -351,6 +355,7 @@ export default function RestaurantDashboard(): JSX.Element {
                             icon={TrendingUp}
                             format="currency"
                             isLoading={isSalesSummaryLoading}
+                            info="Valor médio obtido por mesa servida"
                         />
                     </div>
                     <div className="grid gap-6 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- show additional info for each metric in `MetricCard`
- add tooltip explanations to cards on dashboard home

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: numerous TS and module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869705fd3708333bfdfe5836c33d146