### PR TITLE
Add Reports page documentation

### DIFF
--- a/docs/dashboard-reports-endpoints.md
+++ b/docs/dashboard-reports-endpoints.md
@@ -1,0 +1,41 @@
+# Dashboard Reports Page Endpoints
+
+This document lists backend endpoints required for the Reports page. Existing endpoints are referenced where possible. New ones are suggested when necessary.
+
+## Sales Summary
+- **GET `/analytics/sales-summary`**
+  - Params: `restaurantId`, `startDate`, `endDate`
+  - Returns total sales amount and order count for the period
+- **GET `/analytics/recent-orders`** *(existing)*
+  - Params: `restaurantId`, `days`
+  - Used for quick charts showing order trends
+
+## Invoices
+- **GET `/analytics/invoices`**
+  - Params: `restaurantId`, `startDate`, `endDate`, `status?`
+  - Returns invoice count and totals. Supports filtering by paid/pending.
+- **GET `/invoices/:id/download`** *(new)*
+  - Download individual invoice PDF
+
+## Items Sold
+- **GET `/analytics/top-items`**
+  - Params: `restaurantId`, `startDate`, `endDate`, `category?`
+  - Returns items with quantity sold
+- **GET `/reports/items`** *(new)*
+  - Params: `restaurantId`, `startDate`, `endDate`, `category?`, `status?`
+  - Provides full item-level export (used for CSV/PDF)
+
+## Cancelled Orders/Items
+- **GET `/analytics/cancelled-orders`**
+  - Params: `restaurantId`, `startDate`, `endDate`
+  - Number of cancelled orders and amounts
+- **GET `/reports/cancelled`** *(new)*
+  - Params: `restaurantId`, `startDate`, `endDate`
+  - Detailed list of cancelled items/orders for exports
+
+## Concerns
+- All endpoints must validate that the requesting user has access to the restaurant data
+- Large exports might require background jobs and a download link via email
+- Timezone handling should be consistent between client and server
+- Pagination parameters (`page`, `pageSize`) should be supported for tables
+

--- a/docs/dashboard-reports-page-ux.md
+++ b/docs/dashboard-reports-page-ux.md
@@ -1,0 +1,52 @@
+# Dashboard Reports Page UX
+
+This document outlines the proposed structure, user experience and workflow for the new **Reports** page.
+
+## Goals
+- Allow managers to view and export key sales, invoice and item data
+- Provide filters by date, time and item categories to refine results
+- Support PDF/CSV export for full reports
+
+## Page Layout
+1. **Header**
+   - Page title "Reports"
+   - Quick date range selector (Today, Last 7 days, Last 30 days, Custom)
+   - Export menu with PDF/CSV options for the current view
+2. **Filter Sidebar**
+   - Visible on desktop, collapsible on mobile
+   - Date range picker (start/end date and optional time)
+   - Item category multi‑select
+   - Order status selection (completed, cancelled)
+   - Invoice status selection (paid, pending)
+   - Apply/Reset buttons
+3. **Report Tabs**
+   - Sales Summary
+   - Invoices
+   - Items Sold
+   - Cancelled Items/Orders
+   - Each tab shows a table with sortable columns and pagination
+4. **Results Table**
+   - Displays filtered data for the active tab
+   - Columns adjust per tab (e.g. Items Sold includes quantity)
+   - Download row action for individual invoices/orders when applicable
+5. **Empty State**
+   - Friendly message when no data matches the filters
+
+## Workflow
+1. User opens the Reports page from the dashboard navigation
+2. Default view shows the Sales Summary tab for the last 7 days
+3. User adjusts filters in the sidebar and clicks **Apply**
+4. Frontend fetches data from the relevant endpoints with the selected filters
+5. Tables update to show results
+6. User can switch tabs without losing the current filter state
+7. Export menu downloads the current table data as PDF or CSV
+8. On mobile, filters open in a dialog for ease of use
+
+## Components
+- `ReportsHeader` – contains the title, date presets and export menu
+- `ReportsFilters` – sidebar or dialog with filter controls
+- `ReportsTabs` – manages active tab and renders the correct table
+- `SalesTable`, `InvoicesTable`, `ItemsTable`, `CancelledTable` – table components for each tab
+- `ExportButton` – triggers PDF/CSV generation
+- Reuse existing UI atoms (buttons, inputs, date picker) from the design system
+


### PR DESCRIPTION
## Summary
- document UX flow for new Reports page
- outline backend endpoints required for Reports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails to find dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686972487fc4833396ebdbcf4586fcbc