### PR TITLE
Finalize reports page

### DIFF
--- a/src/api/reports-client.ts
+++ b/src/api/reports-client.ts
@@ -1,0 +1,12 @@
+import axios from "axios";
+import { apiClient } from "@/api/axios";
+
+export const salesReportsClient = axios.create({
+    ...apiClient.defaults,
+    baseURL: `${apiClient.defaults.baseURL}/reports/sales`,
+});
+
+export const invoicesReportsClient = axios.create({
+    ...apiClient.defaults,
+    baseURL: `${apiClient.defaults.baseURL}/reports/invoices`,
+});

--- a/src/components/pages/dashboard-reports/invoices-table.tsx
+++ b/src/components/pages/dashboard-reports/invoices-table.tsx
@@ -8,12 +8,16 @@ import {Invoice} from "@/types/invoice";
 
 interface InvoicesTableProps {
     data: Invoice[]
+    currentPage: number
+    totalPages: number
+    totalCount: number
+    onNextPage: () => void
+    onPrevPage: () => void
 }
 
-export function InvoicesTable({ data }: InvoicesTableProps) {
+export function InvoicesTable({ data, currentPage, totalPages, totalCount, onNextPage, onPrevPage }: InvoicesTableProps) {
     const [sortField, setSortField] = useState<keyof Invoice>("generatedTime")
     const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc")
-    const [currentPage, setCurrentPage] = useState(1)
     const itemsPerPage = 25
 
     const handleSort = (field: keyof Invoice) => {
@@ -36,9 +40,8 @@ export function InvoicesTable({ data }: InvoicesTableProps) {
         return sortDirection === "asc" ? (aValue as number) - (bValue as number) : (bValue as number) - (aValue as number)
     })
 
-    const totalPages = Math.ceil(sortedData.length / itemsPerPage)
     const startIndex = (currentPage - 1) * itemsPerPage
-    const paginatedData = sortedData.slice(startIndex, startIndex + itemsPerPage)
+    const paginatedData = sortedData
 
     const getStatusBadge = (status: string) => {
         const variants = {
@@ -118,26 +121,23 @@ export function InvoicesTable({ data }: InvoicesTableProps) {
             {/* Pagination */}
             <div className="flex items-center justify-between">
                 <div className="text-sm text-muted-foreground">
-                    Showing {startIndex + 1} to {Math.min(startIndex + itemsPerPage, sortedData.length)} of {sortedData.length}{" "}
-                    results
+                    Showing {startIndex + 1} to {Math.min(startIndex + itemsPerPage, totalCount)} of {totalCount} results
                 </div>
                 <div className="flex items-center space-x-2">
                     <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => setCurrentPage(currentPage - 1)}
+                        onClick={onPrevPage}
                         disabled={currentPage === 1}
                     >
                         <ChevronLeft className="h-4 w-4" />
                         Previous
                     </Button>
-                    <div className="text-sm">
-                        Page {currentPage} of {totalPages}
-                    </div>
+                    <div className="text-sm">Page {currentPage} of {totalPages}</div>
                     <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => setCurrentPage(currentPage + 1)}
+                        onClick={onNextPage}
                         disabled={currentPage === totalPages}
                     >
                         Next

--- a/src/components/pages/dashboard-reports/sales-tables.tsx
+++ b/src/components/pages/dashboard-reports/sales-tables.tsx
@@ -13,12 +13,16 @@ interface SalesData {
 
 interface SalesTableProps {
     data: SalesData[]
+    currentPage: number
+    totalPages: number
+    totalCount: number
+    onNextPage: () => void
+    onPrevPage: () => void
 }
 
-export function SalesTable({ data }: SalesTableProps) {
+export function SalesTable({ data, currentPage, totalPages, totalCount, onNextPage, onPrevPage }: SalesTableProps) {
     const [sortField, setSortField] = useState<keyof SalesData>("date")
     const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc")
-    const [currentPage, setCurrentPage] = useState(1)
     const itemsPerPage = 25
 
     const handleSort = (field: keyof SalesData) => {
@@ -41,9 +45,8 @@ export function SalesTable({ data }: SalesTableProps) {
         return sortDirection === "asc" ? (aValue as number) - (bValue as number) : (bValue as number) - (aValue as number)
     })
 
-    const totalPages = Math.ceil(sortedData.length / itemsPerPage)
     const startIndex = (currentPage - 1) * itemsPerPage
-    const paginatedData = sortedData.slice(startIndex, startIndex + itemsPerPage)
+    const paginatedData = sortedData
 
     if (data.length === 0) {
         return (
@@ -95,26 +98,23 @@ export function SalesTable({ data }: SalesTableProps) {
             {/* Pagination */}
             <div className="flex items-center justify-between">
                 <div className="text-sm text-muted-foreground">
-                    Showing {startIndex + 1} to {Math.min(startIndex + itemsPerPage, sortedData.length)} of {sortedData.length}{" "}
-                    results
+                    Showing {startIndex + 1} to {Math.min(startIndex + itemsPerPage, totalCount)} of {totalCount} results
                 </div>
                 <div className="flex items-center space-x-2">
                     <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => setCurrentPage(currentPage - 1)}
+                        onClick={onPrevPage}
                         disabled={currentPage === 1}
                     >
                         <ChevronLeft className="h-4 w-4" />
                         Previous
                     </Button>
-                    <div className="text-sm">
-                        Page {currentPage} of {totalPages}
-                    </div>
+                    <div className="text-sm">Page {currentPage} of {totalPages}</div>
                     <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => setCurrentPage(currentPage + 1)}
+                        onClick={onNextPage}
                         disabled={currentPage === totalPages}
                     >
                         Next

--- a/src/hooks/use-paginate.ts
+++ b/src/hooks/use-paginate.ts
@@ -24,17 +24,18 @@ interface UsePaginatedQueryResult<T> {
 export function usePaginatedQuery<T>(
     axiosClient: AxiosInstance,
     limit: number = 10,
-    url?: string
+    url?: string,
+    params: Record<string, unknown> = {}
 ): UsePaginatedQueryResult<T> {
     const [cursor, setCursor] = useState<string | null>(null);
     const [, setCursorHistory] = useState<(string | null)[]>([]);
     const [currentPage, setCurrentPage] = useState<number>(1);
 
     const { data, isLoading, isError } = useQuery({
-        queryKey: ['paginated', cursor, limit],
+        queryKey: ['paginated', axiosClient.defaults.baseURL, url, JSON.stringify(params), cursor, limit],
         queryFn: async (): Promise<PaginatedResponse<T>> => {
-            const response = await axiosClient.get<PaginatedResponse<T>>(url? url :'/paginate', {
-                params: { cursor, limit },
+            const response = await axiosClient.get<PaginatedResponse<T>>(url ? url : '/paginate', {
+                params: { cursor, limit, ...params },
             });
             return response.data;
         }

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -12,3 +12,10 @@ export interface FilterState {
 }
 
 export type DatePreset = "today" | "last7days" | "last30days" | "custom"
+
+export interface SalesReportRow {
+    date: string
+    grossSales: number
+    netSales: number
+    orders: number
+}


### PR DESCRIPTION
## Summary
- add reports axios clients
- extend `usePaginatedQuery` with extra params support
- rework report tables to accept pagination controls
- load reports with real data and export via API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686984d7d0688333a3f932987cf4e7bf