### PR TITLE
Add invoice API endpoints

### DIFF
--- a/docs/invoice-endpoints.md
+++ b/docs/invoice-endpoints.md
@@ -1,0 +1,18 @@
+# Invoice API Endpoints
+
+This document describes available endpoints for managing invoices.
+
+## CRUD Operations
+- **POST `/invoices/`** – create a new invoice
+- **GET `/invoices/:id`** – retrieve a single invoice
+- **PUT `/invoices/:id`** – update an invoice
+- **DELETE `/invoices/:id`** – remove an invoice
+
+## Additional Operations
+- **GET `/invoices`** – list all invoices
+- **GET `/invoices/paginate`** – cursor based pagination. Accepts `cursor`, `limit` and filter params
+- **GET `/invoices/restaurant/:restaurantId`** – invoices for a specific restaurant
+- **GET `/invoices/session/:sessionId`** – invoices for a table session
+- **PUT `/invoices/:id/pay`** – mark an invoice as paid
+- **POST `/invoices/:id/cancel`** – cancel an invoice
+- **GET `/invoices/:id/download`** – download invoice PDF

--- a/src/api/endpoints/invoices/hooks.ts
+++ b/src/api/endpoints/invoices/hooks.ts
@@ -1,0 +1,50 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { invoicesApi } from "./requests";
+import { Invoice, PartialInvoice } from "@/types/invoice";
+
+export function useGetInvoice(invoiceId: string | undefined) {
+    const queryKey = ["invoice", invoiceId];
+    return useQuery({
+        queryKey,
+        queryFn: () => (invoiceId ? invoicesApi.getInvoice(invoiceId) : undefined),
+        enabled: typeof invoiceId === "string",
+    });
+}
+
+export function useGetRestaurantInvoices(restaurantId: string | undefined) {
+    const queryKey = ["restaurant invoices", restaurantId];
+    return useQuery({
+        queryKey,
+        queryFn: () => (restaurantId ? invoicesApi.listRestaurantInvoices(restaurantId) : undefined),
+        enabled: typeof restaurantId === "string",
+    });
+}
+
+export function useGetSessionInvoices(sessionId: string | undefined) {
+    const queryKey = ["session invoices", sessionId];
+    return useQuery({
+        queryKey,
+        queryFn: () => (sessionId ? invoicesApi.listSessionInvoices(sessionId) : undefined),
+        enabled: typeof sessionId === "string",
+    });
+}
+
+export function useCreateInvoice() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: invoicesApi.createInvoice,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["restaurant invoices"] });
+        },
+    });
+}
+
+export function useUpdateInvoice(invoiceId: string) {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: PartialInvoice) => invoicesApi.updateInvoice(invoiceId, data),
+        onSuccess: (invoice: Invoice) => {
+            queryClient.setQueryData<Invoice>(["invoice", invoiceId], invoice);
+        },
+    });
+}

--- a/src/api/endpoints/invoices/requests.ts
+++ b/src/api/endpoints/invoices/requests.ts
@@ -1,0 +1,70 @@
+import { apiClient } from "@/api/axios";
+import { Invoice, InvoiceCreate, PartialInvoice } from "@/types/invoice";
+
+interface PaginatedResponse<T> {
+    items: T[];
+    nextCursor: string | null;
+    totalCount: number;
+    hasMore: boolean;
+}
+
+const baseRoute = "/invoices";
+
+export const invoicesApi = {
+    createInvoice: async (data: InvoiceCreate) => {
+        const response = await apiClient.post<Invoice>(`${baseRoute}/`, data);
+        return response.data;
+    },
+
+    getInvoice: async (invoiceId: string) => {
+        const response = await apiClient.get<Invoice>(`${baseRoute}/${invoiceId}`);
+        return response.data;
+    },
+
+    updateInvoice: async (invoiceId: string, data: PartialInvoice) => {
+        const response = await apiClient.put<Invoice>(`${baseRoute}/${invoiceId}`, data);
+        return response.data;
+    },
+
+    deleteInvoice: async (invoiceId: string) => {
+        const response = await apiClient.delete<boolean>(`${baseRoute}/${invoiceId}`);
+        return response.data;
+    },
+
+    listInvoices: async () => {
+        const response = await apiClient.get<Invoice[]>(`${baseRoute}`);
+        return response.data;
+    },
+
+    listRestaurantInvoices: async (restaurantId: string) => {
+        const response = await apiClient.get<Invoice[]>(`${baseRoute}/restaurant/${restaurantId}`);
+        return response.data;
+    },
+
+    listSessionInvoices: async (sessionId: string) => {
+        const response = await apiClient.get<Invoice[]>(`${baseRoute}/session/${sessionId}`);
+        return response.data;
+    },
+
+    markInvoicePaid: async (invoiceId: string) => {
+        const response = await apiClient.put<Invoice>(`${baseRoute}/${invoiceId}/pay`);
+        return response.data;
+    },
+
+    cancelInvoice: async (invoiceId: string) => {
+        const response = await apiClient.post<Invoice>(`${baseRoute}/${invoiceId}/cancel`);
+        return response.data;
+    },
+
+    downloadInvoice: async (invoiceId: string) => {
+        const response = await apiClient.get<Blob>(`${baseRoute}/${invoiceId}/download`, {
+            responseType: 'blob'
+        });
+        return response.data;
+    },
+
+    paginateInvoices: async (params: Record<string, unknown>) => {
+        const response = await apiClient.get<PaginatedResponse<Invoice>>(`${baseRoute}/paginate`, { params });
+        return response.data;
+    },
+};

--- a/src/types/invoice.ts
+++ b/src/types/invoice.ts
@@ -14,3 +14,16 @@ export type Invoice = {
     status: InvoiceStatus;
     isActive: boolean;
 };
+
+export type InvoiceCreate = {
+    restaurantId: string;
+    sessionId: string;
+    orders: string[];
+    total?: number | null;
+    tax?: number | null;
+    discount?: number | null;
+    generatedTime: string;
+    status: InvoiceStatus;
+};
+
+export type PartialInvoice = Partial<Omit<Invoice, "id" | "createdAt" | "updatedAt">>;


### PR DESCRIPTION
## Summary
- expand `Invoice` type with `InvoiceCreate` and `PartialInvoice`
- add new `/invoices` request helpers with CRUD, payment and pagination
- provide React Query hooks for invoices
- document available invoice endpoints

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869908255d083338684d8767b24a821