### PR TITLE
Improve item customization checks

### DIFF
--- a/src/components/pages/restaurant-menu-cart/product-additional-note.tsx
+++ b/src/components/pages/restaurant-menu-cart/product-additional-note.tsx
@@ -23,7 +23,7 @@ export function ProductAdditionalInfo() {
     })
 
 
-    const {total, onSubmit} = useProductContext()
+    const {total, onSubmit, allRequiredRulesSatisfied, getMissingRequiredRules} = useProductContext()
 
 
     return (
@@ -49,12 +49,17 @@ export function ProductAdditionalInfo() {
 
                     </div>
                     <ProductQuantity/>
-                    <div className='flex justify-center w-full mt-8 '>
-                        <Button type={total === 0 ? "button" : "submit"}
-                                disabled={total === 0}
+                    <div className='flex justify-center w-full mt-8 flex-col items-center'>
+                        <Button type={total === 0 || !allRequiredRulesSatisfied() ? "button" : "submit"}
+                                disabled={total === 0 || !allRequiredRulesSatisfied()}
                                 className={`self-center mx-auto prevent-select w-full`}>
                             {total === 0 ? "Confirmar" : `Confirmar - ${total}.00 Kz`}
                         </Button>
+                        {!allRequiredRulesSatisfied() && (
+                            <p className='text-xs text-red-600 mt-2 text-center'>
+                                Escolha: {getMissingRequiredRules().join(', ')}
+                            </p>
+                        )}
                     </div>
 
                 </form>

--- a/src/components/pages/restaurant-menu/product.tsx
+++ b/src/components/pages/restaurant-menu/product.tsx
@@ -194,6 +194,12 @@ export function Product({children, item}: props) {
         return item.customizations.every(rule => isRequiredRuleSatisfied(rule))
     }
 
+    const getMissingRequiredRules = () => {
+        return item.customizations
+            .filter(rule => rule.isRequired && !isRequiredRuleSatisfied(rule))
+            .map(rule => rule.name)
+    }
+
 
     function handleSubmit(data: z.infer<typeof AdditionalNoteSchema>) {
         const note = data.note
@@ -233,7 +239,9 @@ export function Product({children, item}: props) {
             getOptionQuantity,
             canSelectMore,
             isOptionSelected,
-            allRequiredRulesSatisfied
+            allRequiredRulesSatisfied,
+            isRequiredRuleSatisfied,
+            getMissingRequiredRules
         }}>
             <Sheet open={isOpen} onOpenChange={setIsOpen}>
                 <SheetTrigger>
@@ -283,7 +291,8 @@ export function ProductContent() {
         handleCustomizationChange,
         getOptionQuantity,
         isOptionSelected,
-        canSelectMore
+        canSelectMore,
+        isRequiredRuleSatisfied
     } = useProductContext()
 
 
@@ -317,7 +326,7 @@ export function ProductContent() {
             {item.customizations.map((rule, ruleIndex) => (
                 <div key={ruleIndex} className='space-y-3 border p-3 rounded-lg'>
                     <div className='flex items-center justify-between'>
-                        <h2 className='font-medium'>
+                        <h2 className={`font-medium ${rule.isRequired && !isRequiredRuleSatisfied(rule) ? 'text-red-600' : ''}`}>
                             {rule.name}{rule.isRequired && <span className='text-red-500 ml-1'>*</span>}
                         </h2>
                         <span className='text-xs'>
@@ -327,6 +336,9 @@ export function ProductContent() {
                             {rule.limitType === "ALL" && "Choose all"}
                         </span>
                     </div>
+                    {rule.isRequired && !isRequiredRuleSatisfied(rule) && (
+                        <p className='text-xs text-red-600'>Seleção obrigatória</p>
+                    )}
                     {rule.options.map((option, optionIndex) => {
                         const selected = isOptionSelected(rule.name, option.name)
                         const qty = getOptionQuantity(rule.name, option.name)

--- a/src/hooks/use-product-context.ts
+++ b/src/hooks/use-product-context.ts
@@ -22,6 +22,8 @@ type ProductContextProps = {
     canSelectMore: (rule: CustomizationRule) => boolean;
     isOptionSelected: (ruleName: string, optionName: string) => boolean;
     allRequiredRulesSatisfied: () => boolean;
+    isRequiredRuleSatisfied: (rule: CustomizationRule) => boolean;
+    getMissingRequiredRules: () => string[];
 }
 
 export const ProductContext = createContext<ProductContextProps | undefined>(undefined)


### PR DESCRIPTION
## Summary
- add customization-aware comparison for cart items
- expand product context with rule helpers
- show incomplete rules in product page
- disable confirm button until rules satisfied

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686d19f3603c8333b1ea50b1bc0bed41