### PR TITLE
Fix dashboard settings page cards

### DIFF
--- a/src/pages/dashboard/settings.tsx
+++ b/src/pages/dashboard/settings.tsx
@@ -284,8 +284,12 @@ export default function Settings() {
                                         </div>
                                     </CardContent>
                                 </Card>
+                                <Card>
+                                    <CardHeader>
                                         <CardTitle>Horário de Funcionamento</CardTitle>
-                                        <CardDescription>Configure os horários de funcionamento do seu restaurante.</CardDescription>
+                                        <CardDescription>
+                                            Configure os horários de funcionamento do seu restaurante.
+                                        </CardDescription>
                                     </CardHeader>
                                     <CardContent>
                                         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- fix card header layout on dashboard settings page

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npx tsc src/pages/dashboard/settings.tsx --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d28acb5a08333995cfc935be1e906