### PR TITLE
Fix dashboard date range handling

### DIFF
--- a/src/lib/helpers/to-local-iso-string.ts
+++ b/src/lib/helpers/to-local-iso-string.ts
@@ -1,0 +1,5 @@
+export function toLocalISOString(date: Date): string {
+    const offsetMs = date.getTimezoneOffset() * 60000;
+    const adjusted = new Date(date.getTime() - offsetMs);
+    return adjusted.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}

--- a/src/pages/dashboard/dashboard-home.tsx
+++ b/src/pages/dashboard/dashboard-home.tsx
@@ -24,6 +24,7 @@ import type {
     ItemsTimeRange,
 } from "@/types/dashboard"
 import {downloadCSV, downloadPDF} from "@/lib/helpers/export";
+import { toLocalISOString } from "@/lib/helpers/to-local-iso-string";
 import {toast} from "sonner";
 import {useDashboardContext} from "@/context/dashboard-context";
 import {
@@ -91,8 +92,10 @@ export default function RestaurantDashboard(): JSX.Element {
                 from.setHours(0, 0, 0, 0)
                 break
             case "yesterday":
-                from.setDate(from.getDate() - 2)
+                from.setDate(from.getDate() - 1)
                 from.setHours(0, 0, 0, 0)
+                to = new Date(from)
+                to.setHours(23, 59, 59, 999)
                 break
             case "7days":
             case "week":
@@ -111,8 +114,8 @@ export default function RestaurantDashboard(): JSX.Element {
         }
 
         return {
-            from: from.toISOString(),
-            to: to ? to.toISOString() : undefined
+            from: toLocalISOString(from),
+            to: to ? toLocalISOString(to) : undefined
         }
     }
 


### PR DESCRIPTION
## Summary
- add `toLocalISOString` helper to preserve local date when converting to ISO
- update dashboard date range logic to set yesterday range correctly and use the helper for all ranges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d30d6339c8333b5afc4ccb0266b17