### PR TITLE
Improve total stock value formatting

### DIFF
--- a/src/pages/dashboard/stock.tsx
+++ b/src/pages/dashboard/stock.tsx
@@ -9,6 +9,7 @@ import {
     ChefHat,
     BarChart3,
 } from "lucide-react"
+import { formatCurrency } from "@/lib/helpers/format-currency"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -956,7 +957,7 @@ export default function StockManagement() {
                         <BarChart3 className="h-4 w-4 text-muted-foreground" />
                     </CardHeader>
                     <CardContent>
-                        <div className="text-2xl font-bold">Kz {totalStockValue.toFixed(2)}</div>
+                        <div className="text-2xl font-bold">Kz {formatCurrency(totalStockValue)}</div>
                         <p className="text-xs text-muted-foreground">
                             Valor total do inventário
                         </p>


### PR DESCRIPTION
## Summary
- import `formatCurrency` helper in stock page
- show total inventory value with thousands separators

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d9eb1e36483339f80d13c1f8c07ab