### PR TITLE
Organize dashboard sidebar links into groups

### DIFF
--- a/src/components/layout/dashboard/components/dashboard-sidebar.tsx
+++ b/src/components/layout/dashboard/components/dashboard-sidebar.tsx
@@ -34,111 +34,129 @@ import {useDashboardContext} from "@/context/dashboard-context";
 import {Sections} from "@/types/role";
 import { usePermissions } from "@/context/permissions-context";
 
-const navigation: {
-    label: string,
-    icon: Icon,
-    href: string,
+type NavigationItem = {
+    label: string
+    icon: Icon
+    href: string
     section?: Sections[]
-}[] = [
+}
+
+type NavigationGroup = {
+    label: string
+    items: NavigationItem[]
+}
+
+const navigation: NavigationGroup[] = [
     {
-        label: "Geral",
-        icon: House,
-        href: "",
-        section: [
-            Sections.SALES_DASHBOARD,
-            Sections.PERFORMANCE_INSIGHTS,
-            Sections.PRODUCT_POPULARITY,
-            Sections.REVENUE_TRENDS
-        ]
+        label: 'Painel',
+        items: [
+            {
+                label: 'Geral',
+                icon: House,
+                href: '',
+                section: [
+                    Sections.SALES_DASHBOARD,
+                    Sections.PERFORMANCE_INSIGHTS,
+                    Sections.PRODUCT_POPULARITY,
+                    Sections.REVENUE_TRENDS,
+                ],
+            },
+            {
+                label: 'Relatórios',
+                icon: ChartDonut,
+                href: 'reports',
+                section: [Sections.REPORTS, Sections.INVOICES],
+            },
+        ],
     },
     {
-        label: "Menu",
-        icon: Book,
-        href: "menu",
-        section: [
-            Sections.MENUS,
-            Sections.CATEGORIES,
-            Sections.ITEMS
-        ]
+        label: 'Menu',
+        items: [
+            {
+                label: 'Menu',
+                icon: Book,
+                href: 'menu',
+                section: [Sections.MENUS, Sections.CATEGORIES, Sections.ITEMS],
+            },
+            {
+                label: 'Stock',
+                icon: Package,
+                href: 'stock',
+                section: [
+                    Sections.STOCK_ITEMS,
+                    Sections.STOCK_MOVEMENTS,
+                    Sections.STOCK_RECIPES,
+                ],
+            },
+        ],
     },
     {
-        label: "QR Codes",
-        icon: QrCode,
-        href: "qrcode",
-        section: [Sections.TABLE_QR_ACCESS_CONTROL]
+        label: 'Operações',
+        items: [
+            {
+                label: 'Pedidos',
+                icon: CallBell,
+                href: 'orders-tracking',
+                section: [Sections.ORDERS],
+            },
+            {
+                label: 'Mesas',
+                icon: Chair,
+                href: 'table-monitor',
+                section: [Sections.TABLES],
+            },
+            {
+                label: 'Reservas',
+                icon: BookmarkSimple,
+                href: 'bookings',
+                section: [Sections.RESERVATIONS],
+            },
+            {
+                label: 'QR Codes',
+                icon: QrCode,
+                href: 'qrcode',
+                section: [Sections.TABLE_QR_ACCESS_CONTROL],
+            },
+        ],
     },
     {
-        label: "Reservas",
-        icon: BookmarkSimple,
-        href: "bookings",
-        section: [Sections.RESERVATIONS]
+        label: 'Equipe',
+        items: [
+            {
+                label: 'Equipe',
+                icon: UsersThree,
+                href: 'staff',
+                section: [Sections.USERS, Sections.ROLES, Sections.PERMISSIONS],
+            },
+            {
+                label: 'Funções',
+                icon: Knife,
+                href: 'roles',
+                section: [Sections.ROLES],
+            },
+        ],
     },
     {
-        label: "Equipe",
-        icon: UsersThree,
-        href: "staff",
-        section: [
-            Sections.USERS,
-            Sections.ROLES,
-            Sections.PERMISSIONS
-        ]
+        label: 'Administração',
+        items: [
+            {
+                label: 'Subscrição',
+                icon: CreditCard,
+                href: 'subscription',
+            },
+            {
+                label: 'Definições',
+                icon: Gear,
+                href: 'settings',
+                section: [Sections.RESTAURANT_SETTINGS, Sections.OPENING_HOURS],
+            },
+            {
+                label: 'Suporte',
+                icon: Lifebuoy,
+                href: 'support',
+            },
+        ],
     },
-    {
-        label: "Funções",
-        icon: Knife,
-        href: "roles",
-        section: [Sections.ROLES]
-    },
-    {
-        label: "Pedidos",
-        icon: CallBell,
-        href: "orders-tracking",
-        section: [Sections.ORDERS]
-    },
-    {
-        label: "Mesas",
-        icon: Chair,
-        href: "table-monitor",
-        section: [Sections.TABLES]
-    },
-    {
-        label: "Stock",
-        icon: Package,
-        href: "stock",
-        section: [
-            Sections.STOCK_ITEMS,
-            Sections.STOCK_MOVEMENTS,
-            Sections.STOCK_RECIPES
-        ]
-    },
-    {
-        label: "Relatórios",
-        icon: ChartDonut,
-        href: "reports",
-        section: [
-            Sections.REPORTS,
-            Sections.INVOICES
-        ]
-    },
-    {
-        label: "Subscrição",
-        icon: CreditCard,
-        href: "subscription",
-    },
-    {
-        label: "Definições",
-        icon: Gear,
-        href: "settings",
-        section: [
-            Sections.RESTAURANT_SETTINGS,
-            Sections.OPENING_HOURS,
-        ]
-    },
-    {
-        label: "Suporte",
-        icon: Lifebuoy,
-        href: "support",
-    }
 ]
 
 const hiddenRoutes = ["none"]
@@ -183,32 +201,46 @@ export default function DashboardSidebar() {
                 </div>
             </SidebarHeader>
             <SidebarContent className="bg-white">
-
-                <SidebarGroup>
-                    <SidebarGroupLabel className="text-primary">Menu</SidebarGroupLabel>
-                    <SidebarMenu>
-                        {navigation
-                            .filter((item) => {
-                                if (!item.section || item.section.length === 0) return true;
-                                return item.section.some((section) => hasPermission(section, "view"));
-                            })
-                            .map((item) => (
-                                !hiddenRoutes.includes(item.href) &&
-                                <SidebarMenuItem className={`${item.href == route? "bg-purple-50 flex rounded-full " : "rounded-full text-zinc-400 hover"} transition-all duration-150 ease-in-out`} key={item.label}>
-                                    <SidebarMenuButton disabled={restaurant._id == "notfound"} className={`rounded-full flex mx-auto ${item.href == route? "hover:bg-purple-100":""} transition-all duration-150 ease-in-out`} asChild>
-                                        <button onClick={() => handlePageChange(item.href)} className={`flex ${!open && !isMobile && "justify-center"} gap-2`}>
-                                            <item.icon className={`${!open ? "ml-2": "ml-0"} ${route == item.href && " text-purple-900"} transition-all duration-100 ease-in-out h-4 w-4`}/>
-                                            <span className={`${route == item.href && " text-purple-900"} `}>
-                                            {item.label}
-                                        </span>
-                                        </button>
-                                    </SidebarMenuButton>
-                                </SidebarMenuItem>
-                                )
-                            )
-                        }
-                    </SidebarMenu>
-                </SidebarGroup>
+                {navigation.map((group) => (
+                    <SidebarGroup key={group.label}>
+                        <SidebarGroupLabel className="text-primary">
+                            {group.label}
+                        </SidebarGroupLabel>
+                        <SidebarMenu>
+                            {group.items
+                                .filter((item) => {
+                                    if (!item.section || item.section.length === 0) return true;
+                                    return item.section.some((section) => hasPermission(section, "view"));
+                                })
+                                .map((item) => (
+                                    !hiddenRoutes.includes(item.href) && (
+                                        <SidebarMenuItem
+                                            className={`${item.href == route ? "bg-purple-50 flex rounded-full " : "rounded-full text-zinc-400 hover"} transition-all duration-150 ease-in-out`}
+                                            key={item.label}
+                                        >
+                                            <SidebarMenuButton
+                                                disabled={restaurant._id == "notfound"}
+                                                className={`rounded-full flex mx-auto ${item.href == route ? "hover:bg-purple-100" : ""} transition-all duration-150 ease-in-out`}
+                                                asChild
+                                            >
+                                                <button
+                                                    onClick={() => handlePageChange(item.href)}
+                                                    className={`flex ${!open && !isMobile && "justify-center"} gap-2`}
+                                                >
+                                                    <item.icon
+                                                        className={`${!open ? "ml-2" : "ml-0"} ${route == item.href && " text-purple-900"} transition-all duration-100 ease-in-out h-4 w-4`}
+                                                    />
+                                                    <span className={`${route == item.href && " text-purple-900"} `}>
+                                                        {item.label}
+                                                    </span>
+                                                </button>
+                                            </SidebarMenuButton>
+                                        </SidebarMenuItem>
+                                    )
+                                ))}
+                        </SidebarMenu>
+                    </SidebarGroup>
+                ))}
             </SidebarContent>
             <SidebarFooter className={`${ !isMobile && open? "opacity-100" : "opacity-0"} transition-opacity duration-300 ease-in-out bg-white`}>
                 <div className="bg-primary mx-auto w-full rounded-md h-28 p-3 flex flex-col justify-between">


### PR DESCRIPTION
## Summary
- group dashboard sidebar links with `SidebarGroup` components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871018688f083338f93cbc285c627a9