### PR TITLE
Improve account creation onboarding

### DIFF
--- a/src/components/pages/onboarding/user-info-step.tsx
+++ b/src/components/pages/onboarding/user-info-step.tsx
@@ -16,9 +16,6 @@ const userInfoSchema = z.object({
     lastName: z.string().min(2, {
         message: "O sobrenome deve ter pelo menos 2 caracteres",
     }),
-    email: z.string().email({
-        message: "Por favor, digite um email válido",
-    }),
     phoneNumber: z.string().min(10, {
         message: "Por favor, digite um número de telefone válido",
     }),
@@ -38,7 +35,6 @@ export function UserInfoStep({ userData, updateUserData, onNext }: UserInfoStepP
         defaultValues: {
             firstName: userData.firstName,
             lastName: userData.lastName,
-            email: userData.email,
             phoneNumber: userData.phoneNumber,
         },
     })


### PR DESCRIPTION
## Summary
- update onboarding signup info step to stop asking for email

## Testing
- `npx tsc --noEmit` *(fails: Output file has not been built from source)*

------
https://chatgpt.com/codex/tasks/task_e_687bb35dcf0483339759d1f5dc2461fc