### PR TITLE
Implement subscription API hooks

### DIFF
--- a/src/api/endpoints/subscriptions/hooks.ts
+++ b/src/api/endpoints/subscriptions/hooks.ts
@@ -1,0 +1,107 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { subscriptionsApi } from "./requests";
+import { showSuccessToast, showErrorToast } from "@/utils/notifications/toast";
+
+export function useGetCurrentSubscription() {
+    return useQuery({
+        queryKey: ["subscription", "current"],
+        queryFn: subscriptionsApi.getCurrentSubscription,
+    });
+}
+
+export function useGetUsageMetrics() {
+    return useQuery({
+        queryKey: ["subscription", "usage"],
+        queryFn: subscriptionsApi.getUsageMetrics,
+    });
+}
+
+export function useGetPaymentHistory(params?: { from?: string; to?: string; status?: string }) {
+    const { from = "", to = "", status = "" } = params || {};
+    return useQuery({
+        queryKey: ["subscription", "history", from, to, status],
+        queryFn: () => subscriptionsApi.listPaymentHistory(params),
+    });
+}
+
+export function useGetPlans() {
+    return useQuery({
+        queryKey: ["plans", "all"],
+        queryFn: subscriptionsApi.getPlans,
+    });
+}
+
+export function useChangePlan() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: subscriptionsApi.changePlan,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["subscription", "current"] });
+            showSuccessToast("Plano alterado com sucesso");
+        },
+        onError: () => {
+            showErrorToast("Falha ao alterar plano");
+        },
+    });
+}
+
+export function useUploadPaymentProof() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: subscriptionsApi.uploadPaymentProof,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["subscription", "history"] });
+            showSuccessToast("Comprovativo enviado com sucesso");
+        },
+        onError: () => {
+            showErrorToast("Erro ao enviar comprovativo");
+        },
+    });
+}
+
+export function useGetLatestInvoice() {
+    return useQuery({
+        queryKey: ["payments", "latest"],
+        queryFn: subscriptionsApi.getLatestInvoice,
+    });
+}
+
+export function useDownloadInvoice() {
+    return useMutation({
+        mutationFn: subscriptionsApi.downloadInvoice,
+    });
+}
+
+export function usePauseSubscription() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: subscriptionsApi.pauseSubscription,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["subscription", "current"] });
+            showSuccessToast("Subscrição pausada");
+        },
+        onError: () => {
+            showErrorToast("Erro ao pausar subscrição");
+        },
+    });
+}
+
+export function useResumeSubscription() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: subscriptionsApi.resumeSubscription,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["subscription", "current"] });
+            showSuccessToast("Subscrição retomada");
+        },
+        onError: () => {
+            showErrorToast("Erro ao retomar subscrição");
+        },
+    });
+}
+
+export function useBackupAccountData() {
+    return useMutation({
+        mutationFn: subscriptionsApi.backupAccountData,
+    });
+}

--- a/src/api/endpoints/subscriptions/requests.ts
+++ b/src/api/endpoints/subscriptions/requests.ts
@@ -1,0 +1,70 @@
+import { apiClient } from "@/api/axios";
+import { Subscription, UsageMetrics, PaymentHistory, Plan } from "@/types/subscription";
+import { Invoice } from "@/types/invoice";
+
+const baseRoute = "/subscriptions";
+const paymentsRoute = "/payments";
+const plansRoute = "/plans";
+
+export const subscriptionsApi = {
+    getCurrentSubscription: async () => {
+        const response = await apiClient.get<Subscription>(`${baseRoute}/current`);
+        return response.data;
+    },
+
+    getUsageMetrics: async () => {
+        const response = await apiClient.get<UsageMetrics>(`${baseRoute}/usage`);
+        return response.data;
+    },
+
+    listPaymentHistory: async (params?: { from?: string; to?: string; status?: string }) => {
+        const response = await apiClient.get<PaymentHistory[]>(`${paymentsRoute}/history`, { params });
+        return response.data;
+    },
+
+    getPlans: async () => {
+        const response = await apiClient.get<Plan[]>(`${plansRoute}/all`);
+        return response.data;
+    },
+
+    changePlan: async (payload: { planId: string; reason?: string }) => {
+        const response = await apiClient.post<Subscription>(`${baseRoute}/change-plan`, payload);
+        return response.data;
+    },
+
+    uploadPaymentProof: async (formData: FormData) => {
+        const response = await apiClient.post(`${paymentsRoute}/proofs`, formData, {
+            headers: { "Content-Type": "multipart/form-data" },
+        });
+        return response.data;
+    },
+
+    getLatestInvoice: async () => {
+        const response = await apiClient.get<Invoice>(`${paymentsRoute}/latest`);
+        return response.data;
+    },
+
+    downloadInvoice: async (invoiceId: string) => {
+        const response = await apiClient.get<Blob>(`${paymentsRoute}/${invoiceId}/download`, {
+            responseType: "blob",
+        });
+        return response.data;
+    },
+
+    pauseSubscription: async (payload?: { reason?: string }) => {
+        const response = await apiClient.post<Subscription>(`${baseRoute}/pause`, payload);
+        return response.data;
+    },
+
+    resumeSubscription: async () => {
+        const response = await apiClient.post<Subscription>(`${baseRoute}/resume`);
+        return response.data;
+    },
+
+    backupAccountData: async () => {
+        const response = await apiClient.post<Blob>(`${baseRoute}/backup`, null, {
+            responseType: "blob",
+        });
+        return response.data;
+    },
+};


### PR DESCRIPTION
## Summary
- add requests for subscription endpoints
- create React Query hooks for dashboard subscription APIs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687cf1f2e9c483338a8c1b12d69d629b