### PR TITLE
Fix sidebar group labels

### DIFF
--- a/src/components/layout/dashboard/components/dashboard-sidebar.tsx
+++ b/src/components/layout/dashboard/components/dashboard-sidebar.tsx
@@ -202,46 +202,47 @@ export default function DashboardSidebar() {
             </SidebarHeader>
             <SidebarContent className="bg-white">
                 {navigation.map((group) => {
+                    const visibleItems = group.items
+                        .filter((item) => {
+                            if (!item.section || item.section.length === 0) return true
+                            return item.section.some((section) => hasPermission(section, "view"))
+                        })
+                        .filter((item) => !hiddenRoutes.includes(item.href))
 
-
+                    if (visibleItems.length === 0) return null
 
                     return (
                         <SidebarGroup className="-mb-4" key={group.label}>
-                            <SidebarGroupLabel className="text-primary">
-                                {group.label}
-                            </SidebarGroupLabel>
+                            {group.label && (
+                                <SidebarGroupLabel className="text-primary">
+                                    {group.label}
+                                </SidebarGroupLabel>
+                            )}
                             <SidebarMenu>
-                                {group.items
-                                    .filter((item) => {
-                                        if (!item.section || item.section.length === 0) return true;
-                                        return item.section.some((section) => hasPermission(section, "view"));
-                                    })
-                                    .map((item) => (
-                                        !hiddenRoutes.includes(item.href) && (
-                                            <SidebarMenuItem
-                                                className={`${item.href == route ? "bg-purple-50 flex rounded-full " : "rounded-full text-zinc-400 hover"} transition-all duration-150 ease-in-out`}
-                                                key={item.label}
+                                {visibleItems.map((item) => (
+                                    <SidebarMenuItem
+                                        className={`${item.href == route ? "bg-purple-50 flex rounded-full " : "rounded-full text-zinc-400 hover"} transition-all duration-150 ease-in-out`}
+                                        key={item.label}
+                                    >
+                                        <SidebarMenuButton
+                                            disabled={restaurant._id == "notfound"}
+                                            className={`rounded-full flex mx-auto ${item.href == route ? "hover:bg-purple-100" : ""} transition-all duration-150 ease-in-out`}
+                                            asChild
+                                        >
+                                            <button
+                                                onClick={() => handlePageChange(item.href)}
+                                                className={`flex ${!open && !isMobile && "justify-center"} gap-2`}
                                             >
-                                                <SidebarMenuButton
-                                                    disabled={restaurant._id == "notfound"}
-                                                    className={`rounded-full flex mx-auto ${item.href == route ? "hover:bg-purple-100" : ""} transition-all duration-150 ease-in-out`}
-                                                    asChild
-                                                >
-                                                    <button
-                                                        onClick={() => handlePageChange(item.href)}
-                                                        className={`flex ${!open && !isMobile && "justify-center"} gap-2`}
-                                                    >
-                                                        <item.icon
-                                                            className={`${!open ? "ml-2" : "ml-0"} ${route == item.href && " text-purple-900"} transition-all duration-100 ease-in-out h-4 w-4`}
-                                                        />
-                                                        <span className={`${route == item.href && " text-purple-900"} `}>
-                                                        {item.label}
-                                                    </span>
-                                                    </button>
-                                                </SidebarMenuButton>
-                                            </SidebarMenuItem>
-                                        )
-                                    ))}
+                                                <item.icon
+                                                    className={`${!open ? "ml-2" : "ml-0"} ${route == item.href && " text-purple-900"} transition-all duration-100 ease-in-out h-4 w-4`}
+                                                />
+                                                <span className={`${route == item.href && " text-purple-900"} `}>
+                                                    {item.label}
+                                                </span>
+                                            </button>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                ))}
                             </SidebarMenu>
                         </SidebarGroup>
                     )


### PR DESCRIPTION
## Summary
- refactor dashboard sidebar to only render groups with visible items

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6883adb3358c8333a9b7689ba71a3586