### PR TITLE
feat: add assistance button for table

### DIFF
--- a/src/components/pages/restaurant-menu/table-info.tsx
+++ b/src/components/pages/restaurant-menu/table-info.tsx
@@ -1,25 +1,52 @@
-import {useMenuContext} from "@/context/menu-context";
-import {Bell} from "lucide-react";
-import {ClosedRestaurant, OpenRestaurant} from "@/components/pages/restaurant-menu/availability";
-import {Badge} from "@/components/ui/badge";
+import { useMenuContext } from "@/context/menu-context";
+import { useRestaurantMenuContext } from "@/context/restaurant-menu-context";
+import { Bell } from "lucide-react";
+import { ClosedRestaurant, OpenRestaurant } from "@/components/pages/restaurant-menu/availability";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { sessionApi } from "@/api/endpoints/sessions/requests";
+import { TableSession } from "@/types/table-session";
 
 export function TableInfo() {
 
-    const {tableNumber, open} = useMenuContext()
+    const { tableNumber, open, restaurant } = useMenuContext();
+    const { session } = useRestaurantMenuContext();
+
+    const queryClient = useQueryClient();
+    const queryKey = ["active", tableNumber, restaurant._id];
+
+    const needsAssistance = session.needsAssistance ?? false;
+
+    const { mutate: toggleAssistance, isLoading } = useMutation({
+        mutationFn: () =>
+            needsAssistance
+                ? sessionApi.cancelAssistanceRequest(session._id)
+                : sessionApi.requestAssistance(session._id),
+        onSuccess: (updatedSession) => {
+            queryClient.setQueryData<TableSession>(queryKey, updatedSession);
+        },
+    });
 
     return (
-        <div className={`my-4 flex space-x-4`}>
+        <div className={"my-4 flex space-x-4 items-center"}>
             {
                 open ? <OpenRestaurant/> : <ClosedRestaurant/>
             }
             <Badge className="font-jost text-zinc-500 rounded-full bg-gray-100 px-2" variant="secondary">
                 Mesa {tableNumber}
             </Badge>
-            <div
-                className='hidden ml-5 items-center rounded-xl px-3 bg-gray-100 hover:bg-gray-200 cursor-pointer py-0.5 prevent-select'>
-                <Bell className='m-1 laptop:mr-1 laptop:my-0 laptop:ml-0'/>
-                <p className='text-gray-600 font-poppins-semibold hidden laptop:block'>Chamar Garçon</p>
-            </div>
+            <Button
+                variant={needsAssistance ? "destructive" : "secondary"}
+                size="sm"
+                icon={Bell}
+                iconPlacement="left"
+                className="px-3"
+                disabled={isLoading}
+                onClick={() => toggleAssistance()}
+            >
+                {needsAssistance ? "Cancelar chamado" : "Chamar Garçon"}
+            </Button>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add assistance button to table info and toggle assistance status

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f7836bc4833388460e2e3470dcd2