### PR TITLE
feat: sync local lists after stock and recipe mutations

### DIFF
--- a/src/api/endpoints/recipes/hooks.ts
+++ b/src/api/endpoints/recipes/hooks.ts
@@ -1,19 +1,48 @@
 import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query";
 import {recipesApi} from "./requests";
+import {recipesClient} from "@/api";
 import {Recipe, RecipeCreate} from "@/types/stock";
+
+type PaginatedResponse<T> = {
+    items: T[];
+    nextCursor: string | null;
+    totalCount: number;
+    hasMore: boolean;
+};
 
 export function useGetRecipes(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["recipes", restaurantId];
+    const paginatedKey = ["paginated", recipesClient.defaults.baseURL];
 
     const addRecipe = (recipe: Recipe) => {
         queryClient.setQueryData<Recipe[]>(queryKey, (old = []) => [...old, recipe]);
+        queryClient.setQueriesData<PaginatedResponse<Recipe>>({queryKey: paginatedKey}, (old) =>
+            old ? {
+                ...old,
+                items: [recipe, ...old.items],
+                totalCount: (old.totalCount ?? 0) + 1,
+            } : old
+        );
     };
     const removeRecipe = (id: string) => {
         queryClient.setQueryData<Recipe[]>(queryKey, (old = []) => old.filter(r => r._id !== id));
+        queryClient.setQueriesData<PaginatedResponse<Recipe>>({queryKey: paginatedKey}, (old) =>
+            old ? {
+                ...old,
+                items: old.items.filter(r => r._id !== id),
+                totalCount: Math.max(0, (old.totalCount ?? 0) - 1),
+            } : old
+        );
     };
     const updateRecipe = (updated: Recipe) => {
         queryClient.setQueryData<Recipe[]>(queryKey, (old = []) => old.map(r => r._id === updated._id ? updated : r));
+        queryClient.setQueriesData<PaginatedResponse<Recipe>>({queryKey: paginatedKey}, (old) =>
+            old ? {
+                ...old,
+                items: old.items.map(r => r._id === updated._id ? updated : r),
+            } : old
+        );
     };
 
     const query = useQuery({
@@ -28,11 +57,19 @@ export function useGetRecipes(restaurantId: string) {
 export function useCreateRecipe(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["recipes", restaurantId];
+    const paginatedKey = ["paginated", recipesClient.defaults.baseURL];
 
     return useMutation({
         mutationFn: (data: RecipeCreate) => recipesApi.createRecipe(restaurantId, data),
         onSuccess: (recipe) => {
             queryClient.setQueryData<Recipe[]>(queryKey, (old = []) => [...old, recipe]);
+            queryClient.setQueriesData<PaginatedResponse<Recipe>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: [recipe, ...old.items],
+                    totalCount: (old.totalCount ?? 0) + 1,
+                } : old
+            );
         },
     });
 }
@@ -40,11 +77,18 @@ export function useCreateRecipe(restaurantId: string) {
 export function useUpdateRecipe(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["recipes", restaurantId];
+    const paginatedKey = ["paginated", recipesClient.defaults.baseURL];
 
     return useMutation({
         mutationFn: ({id, data}: {id: string; data: Partial<Recipe>}) => recipesApi.updateRecipe(id, data),
         onSuccess: (recipe) => {
             queryClient.setQueryData<Recipe[]>(queryKey, (old = []) => old.map(r => r._id === recipe._id ? recipe : r));
+            queryClient.setQueriesData<PaginatedResponse<Recipe>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: old.items.map(r => r._id === recipe._id ? recipe : r),
+                } : old
+            );
         },
     });
 }
@@ -52,11 +96,19 @@ export function useUpdateRecipe(restaurantId: string) {
 export function useDeleteRecipe(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["recipes", restaurantId];
+    const paginatedKey = ["paginated", recipesClient.defaults.baseURL];
 
     return useMutation({
         mutationFn: (id: string) => recipesApi.deleteRecipe(id),
         onSuccess: (_, id) => {
             queryClient.setQueryData<Recipe[]>(queryKey, (old = []) => old.filter(r => r._id !== id));
+            queryClient.setQueriesData<PaginatedResponse<Recipe>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: old.items.filter(r => r._id !== id),
+                    totalCount: Math.max(0, (old.totalCount ?? 0) - 1),
+                } : old
+            );
         },
     });
 }

--- a/src/api/endpoints/stock/hooks.ts
+++ b/src/api/endpoints/stock/hooks.ts
@@ -1,19 +1,48 @@
 import {useQuery, useMutation, useQueryClient} from "@tanstack/react-query";
 import {stockApi} from "@/api/endpoints/stock/requests";
+import {stockItemClient} from "@/api";
 import {StockItem, StockItemCreate} from "@/types/stock";
+
+type PaginatedResponse<T> = {
+    items: T[];
+    nextCursor: string | null;
+    totalCount: number;
+    hasMore: boolean;
+};
 
 export function useGetStockItems(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["stock-items", restaurantId];
+    const paginatedKey = ["paginated", stockItemClient.defaults.baseURL, `/restaurant/${restaurantId}/paginate`];
 
     const addItem = (item: StockItem) => {
         queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => [...old, item]);
+        queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+            old ? {
+                ...old,
+                items: [item, ...old.items],
+                totalCount: (old.totalCount ?? 0) + 1,
+            } : old
+        );
     };
     const removeItem = (id: string) => {
         queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => old.filter(i => i._id !== id));
+        queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+            old ? {
+                ...old,
+                items: old.items.filter(i => i._id !== id),
+                totalCount: Math.max(0, (old.totalCount ?? 0) - 1),
+            } : old
+        );
     };
     const updateItem = (updated: StockItem) => {
         queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => old.map(i => i._id === updated._id ? updated : i));
+        queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+            old ? {
+                ...old,
+                items: old.items.map(i => i._id === updated._id ? updated : i),
+            } : old
+        );
     };
 
     const query = useQuery({
@@ -28,11 +57,19 @@ export function useGetStockItems(restaurantId: string) {
 export function useCreateStockItem(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["stock-items", restaurantId];
+    const paginatedKey = ["paginated", stockItemClient.defaults.baseURL, `/restaurant/${restaurantId}/paginate`];
 
     return useMutation({
         mutationFn: (data: StockItemCreate) => stockApi.createItem(restaurantId, data),
         onSuccess: (item) => {
             queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => [...old, item]);
+            queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: [item, ...old.items],
+                    totalCount: (old.totalCount ?? 0) + 1,
+                } : old
+            );
         },
     });
 }
@@ -40,11 +77,18 @@ export function useCreateStockItem(restaurantId: string) {
 export function useUpdateStockItem(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["stock-items", restaurantId];
+    const paginatedKey = ["paginated", stockItemClient.defaults.baseURL, `/restaurant/${restaurantId}/paginate`];
 
     return useMutation({
         mutationFn: ({id, data}: {id: string; data: Partial<StockItem>}) => stockApi.updateItem(id, data),
         onSuccess: (item) => {
             queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => old.map(i => i._id === item._id ? item : i));
+            queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: old.items.map(i => i._id === item._id ? item : i),
+                } : old
+            );
         },
     });
 }
@@ -52,11 +96,19 @@ export function useUpdateStockItem(restaurantId: string) {
 export function useDeleteStockItem(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["stock-items", restaurantId];
+    const paginatedKey = ["paginated", stockItemClient.defaults.baseURL, `/restaurant/${restaurantId}/paginate`];
 
     return useMutation({
         mutationFn: (id: string) => stockApi.deleteItem(id),
         onSuccess: (_, id) => {
             queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => old.filter(i => i._id !== id));
+            queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: old.items.filter(i => i._id !== id),
+                    totalCount: Math.max(0, (old.totalCount ?? 0) - 1),
+                } : old
+            );
         },
     });
 }
@@ -64,11 +116,18 @@ export function useDeleteStockItem(restaurantId: string) {
 export function useAddStock(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["stock-items", restaurantId];
+    const paginatedKey = ["paginated", stockItemClient.defaults.baseURL, `/restaurant/${restaurantId}/paginate`];
 
     return useMutation({
         mutationFn: ({id, data}: {id: string; data: {quantity: number; reason?: string}}) => stockApi.addStock(id, data),
         onSuccess: (item) => {
             queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => old.map(i => i._id === item._id ? item : i));
+            queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: old.items.map(i => i._id === item._id ? item : i),
+                } : old
+            );
         },
     });
 }
@@ -76,11 +135,18 @@ export function useAddStock(restaurantId: string) {
 export function useRemoveStock(restaurantId: string) {
     const queryClient = useQueryClient();
     const queryKey = ["stock-items", restaurantId];
+    const paginatedKey = ["paginated", stockItemClient.defaults.baseURL, `/restaurant/${restaurantId}/paginate`];
 
     return useMutation({
         mutationFn: ({id, data}: {id: string; data: {quantity: number; reason?: string}}) => stockApi.removeStock(id, data),
         onSuccess: (item) => {
             queryClient.setQueryData<StockItem[]>(queryKey, (old = []) => old.map(i => i._id === item._id ? item : i));
+            queryClient.setQueriesData<PaginatedResponse<StockItem>>({queryKey: paginatedKey}, (old) =>
+                old ? {
+                    ...old,
+                    items: old.items.map(i => i._id === item._id ? item : i),
+                } : old
+            );
         },
     });
 }


### PR DESCRIPTION
## Summary
- keep stock item cache in sync for create/update/delete/add/remove mutations
- sync recipe cache with paginated lists after mutation calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68928102eeec8333b55673e794dd76aa