### PR TITLE
refactor: use luxon time utils on staff page

### DIFF
--- a/src/components/pages/dashboard-staff/invitation-card.tsx
+++ b/src/components/pages/dashboard-staff/invitation-card.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react"
-import { format } from "date-fns"
-import { ptBR } from "date-fns/locale"
+import { formatDate } from "@/utils/time"
 import { useQueryClient } from "@tanstack/react-query"
 import { Copy, Trash2 } from "lucide-react"
 
@@ -82,7 +81,7 @@ export function InvitationCard({ invitation }: { invitation: Invitation }) {
             </div>
             <div className="text-sm text-gray-500">{roleName}</div>
             <div className="text-sm">
-                {format(new Date(invitation.createdAt), "dd/MM/yyyy", { locale: ptBR })}
+                {formatDate(invitation.createdAt, "dd/MM/yyyy")}
             </div>
         </Card>
     )

--- a/src/components/pages/dashboard-staff/invitations-table.tsx
+++ b/src/components/pages/dashboard-staff/invitations-table.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { format } from "date-fns";
-import { ptBR } from "date-fns/locale";
+import { formatDate } from "@/utils/time";
 import { Invitation } from "@/types/invitation";
 import { Button } from "@/components/ui/button";
 import { Copy, Trash2 } from "lucide-react";
@@ -72,7 +71,7 @@ function InvitationRow({ invitation }: { invitation: Invitation }) {
         <TableRow>
             <TableCell>{invitation.name}</TableCell>
             <TableCell>{roleName}</TableCell>
-            <TableCell>{format(new Date(invitation.createdAt), "dd/MM/yyyy", { locale: ptBR })}</TableCell>
+            <TableCell>{formatDate(invitation.createdAt, "dd/MM/yyyy")}</TableCell>
             <TableCell className="flex justify-end gap-2">
                 <Button variant="ghost" size="sm" onClick={handleCopy}>
                     <Copy className="w-4 h-4" />

--- a/src/components/pages/dashboard-staff/member-card.tsx
+++ b/src/components/pages/dashboard-staff/member-card.tsx
@@ -13,8 +13,7 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Edit, Eye, MoreHorizontal, Phone, Trash2 } from "lucide-react"
-import { format } from "date-fns"
-import { ptBR } from "date-fns/locale"
+import { formatDateTime } from "@/utils/time"
 import { useDashboardStaff } from "@/context/dashboard-staff-context"
 import { useDashboardContext } from "@/context/dashboard-context"
 import { useListRestaurantRoles } from "@/hooks/use-list-restaurant-roles"
@@ -123,7 +122,7 @@ export function MemberCard({ member }: MemberCardProps) {
                 </div>
                 <div className="flex items-center justify-between">
                     <span className="text-sm text-gray-500">Último acesso:</span>
-                    <span className="text-sm">{format(member.updatedAt, "dd/MM/yyyy HH:mm", { locale: ptBR })}</span>
+                    <span className="text-sm">{formatDateTime(member.updatedAt, "dd/MM/yyyy HH:mm")}</span>
                 </div>
                 <div className="flex items-center gap-1 text-sm">
                     <Phone className="w-3 h-3" />

--- a/src/components/pages/dashboard-staff/member-row.tsx
+++ b/src/components/pages/dashboard-staff/member-row.tsx
@@ -21,8 +21,7 @@ import { TableRow, TableCell } from "@/components/ui/table"
 import { useDashboardStaff } from "@/context/dashboard-staff-context"
 import { useDashboardContext } from "@/context/dashboard-context"
 import { useListRestaurantRoles } from "@/hooks/use-list-restaurant-roles"
-import { format } from "date-fns"
-import { ptBR } from "date-fns/locale"
+import { formatDateTime } from "@/utils/time"
 import { Clock, Eye, Mail, MoreHorizontal, Phone, Trash2 } from "lucide-react"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Badge } from "@/components/ui/badge"
@@ -139,7 +138,7 @@ export default function MemberRow({ user }: MemberRowProps) {
                 <TableCell>
                     <div className="flex items-center gap-1 text-sm">
                         <Clock className="w-3 h-3" />
-                        {format(user.lastLogged ? user.lastLogged : user.updatedAt, "dd/MM/yyyy HH:mm", { locale: ptBR })}
+                        {formatDateTime(user.lastLogged ? user.lastLogged : user.updatedAt, "dd/MM/yyyy HH:mm")}
                     </div>
                 </TableCell>
                 <TableCell>

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -15,13 +15,17 @@ export const toDateTime = (value: DateInput): DateTime => {
 
 export const now = (): DateTime => DateTime.now().setZone(WAT_ZONE);
 
-export const formatDate = (value: DateInput, format = 'dd LLL yyyy'): string =>
-    toDateTime(value).toFormat(format);
+export const formatDate = (
+    value: DateInput,
+    format = 'dd LLL yyyy',
+    locale = 'en'
+): string => toDateTime(value).setLocale(locale).toFormat(format);
 
 export const formatDateTime = (
     value: DateInput,
-    format = 'dd LLL yyyy HH:mm'
-): string => toDateTime(value).toFormat(format);
+    format = 'dd LLL yyyy HH:mm',
+    locale = 'en'
+): string => toDateTime(value).setLocale(locale).toFormat(format);
 
 export const formatLocaleString = (
     value: DateInput,


### PR DESCRIPTION
## Summary
- add locale-aware helpers to `utils/time`
- replace `date-fns` usage in staff dashboard components with Luxon helpers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68928c3ffd5c833394cef2fae8ed1088