### PR TITLE
feat: display role permission groups horizontally

### DIFF
--- a/src/pages/dashboard/roles.tsx
+++ b/src/pages/dashboard/roles.tsx
@@ -399,9 +399,9 @@ export default function RolesPage() {
                     </div>
                     <div>
                         <Label>Permissões</Label>
-                        <div className="mt-2 space-y-4 overflow-y-auto">
+                        <div className="mt-2 flex gap-4 overflow-x-auto pb-4">
                             {Object.entries(groupedPermissions).map(([category, permissions]) => (
-                                <div key={category}>
+                                <div key={category} className="min-w-[16rem]">
                                     <h4 className="font-medium text-sm text-gray-700 mb-2">{category}</h4>
                                     <div className="space-y-2 ml-4">
                                         {permissions.map(permission => (


### PR DESCRIPTION
## Summary
- show role permission groups in a horizontal row to improve responsive layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689291b1cb3c8333b921866a0c00c3aa