### PR TITLE
Fix missing subscription ID in pause mutation

### DIFF
--- a/src/pages/dashboard/subscription.tsx
+++ b/src/pages/dashboard/subscription.tsx
@@ -244,8 +244,11 @@ export default function Subscription() {
 
     // 6. Pausar Conta Temporariamente
     const handlePauseAccount = async () => {
+        const subscriptionId = currentSubscription?._id
+        if (!subscriptionId) return
+
         showPromiseToast(
-            pauseSubscriptionMutation.mutateAsync({}).then(() => {
+            pauseSubscriptionMutation.mutateAsync({ subscriptionId }).then(() => {
                 setShowPauseDialog(false)
             }),
             {


### PR DESCRIPTION
## Summary
- ensure pause subscription mutation receives required subscriptionId

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892bc9181308333a4a04dc3492927cc