### PR TITLE
Disable bill request toast and deactivate button instantly

### DIFF
--- a/src/components/pages/restaurant-menu-orders/payment-methods.tsx
+++ b/src/components/pages/restaurant-menu-orders/payment-methods.tsx
@@ -2,12 +2,9 @@ import {ReactNode} from "react";
 import {useOrdersContext} from "@/context/order-context";
 import {SwipeToConfirmButton} from "@/components/pages/restaurant-menu-orders/swipe-to-confirm";
 import {Banknote, CreditCard} from "lucide-react";
-import {showPromiseToast} from "@/utils/notifications/toast";
 import {useRestaurantMenuContext} from "@/context/restaurant-menu-context";
 import {useMarkSessionNeedsBill} from "@/api/endpoints/sessions/hooks";
 import {useParams} from "react-router";
-
-
 
 interface Props {
     children: ReactNode;
@@ -22,7 +19,7 @@ export function PaymentMethods({children}: Props) {
 }
 
 PaymentMethods.Confirm = function Confirm() {
-    const {refreshOrders, setBillDialogOpen} = useOrdersContext()
+    const {refreshOrders, setBillDialogOpen, setBillRequested} = useOrdersContext()
     const { session, restaurant } = useRestaurantMenuContext()
     const { tableNumber } = useParams() as unknown as { tableNumber: string }
 
@@ -32,21 +29,16 @@ PaymentMethods.Confirm = function Confirm() {
         tableNumber: Number(tableNumber)
     })
 
-
     const handleRequestBill = async () => {
         setBillDialogOpen(true)
+        setBillRequested(true)
 
-        showPromiseToast(
-            requestBill.mutateAsync()
-                .then(() => {
-                    refreshOrders()
-                }),
-            {
-                loading: "Pedindo a conta...",
-                success: "Conta está a caminho!",
-                error: "Falha ao pedir a conta. Tente novamente."
-            }
-        )
+        try {
+            await requestBill.mutateAsync()
+            refreshOrders()
+        } catch (error) {
+            console.error(error)
+        }
     }
 
     return (

--- a/src/context/order-context.ts
+++ b/src/context/order-context.ts
@@ -10,6 +10,7 @@ interface ContextProps {
     cleanList: () => void
     setBillDialogOpen: (open: boolean) => void
     billRequested: boolean
+    setBillRequested: (requested: boolean) => void
 }
 
 export const OrdersContext = createContext<ContextProps | undefined>(undefined)

--- a/src/pages/restaurant/orders.tsx
+++ b/src/pages/restaurant/orders.tsx
@@ -88,6 +88,7 @@ export function Orders() {
             cleanList,
             setBillDialogOpen: setIsPopupOpen,
             billRequested,
+            setBillRequested,
         }}>
             <div className="p-4">
                 <Background className={`bg-gray-100`}/>


### PR DESCRIPTION
## Summary
- add setter to orders context so bill requests can be flagged immediately
- open bill request dialog and remove toast notifications
- update bill request buttons to disable right away after confirming

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e0f022a883339b74805a192da9de