### PR TITLE
Fix session duration per table in Monitor de Mesas

### DIFF
--- a/src/pages/dashboard/table-monitor.tsx
+++ b/src/pages/dashboard/table-monitor.tsx
@@ -322,14 +322,12 @@ export default function TableMonitor() {
                                     </div>
                                     {session && session.orders.length > 0 && (
                                         <div className="mt-2 space-y-1 text-xs text-gray-600">
-                                                {
-                                                    firstOrderTime && (
-                                                        <div className="flex items-center gap-1">
-                                                            <Clock className="h-3 w-3" />
-                                                            {formatDuration(firstOrderTime)}
-                                                        </div>
-                                                    )
-                                                }
+                                            {session.startTime && (
+                                                <div className="flex items-center gap-1">
+                                                    <Clock className="h-3 w-3" />
+                                                    {formatDuration(session.startTime)}
+                                                </div>
+                                            )}
                                             {session.total && (
                                                 <div className="font-medium text-gray-900">{formatCurrency(session.total)}</div>
                                             )}


### PR DESCRIPTION
## Summary
- compute session duration per table card using each session's start time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894e4d492d483339d1434bd4ce7b4d2