### PR TITLE
Keep order details panel visible on scroll

### DIFF
--- a/src/pages/dashboard/order-tracking.tsx
+++ b/src/pages/dashboard/order-tracking.tsx
@@ -174,8 +174,10 @@ export function OrdersTracking() {
                                                     {
                                                         isDesktop ?
                                                             <div
-                                                                className={` transition-all duration-150 ease-in-out ${orderSelected === null ? 'lg:hidden' : 'lg:block lg:w-1/2 lg:sticky lg:top-0'}`}> 
-                                                                {orderSelected && <OrderInfo order={orderSelected}/>}
+                                                                className={`transition-all duration-150 ease-in-out ${orderSelected === null ? 'lg:hidden' : 'lg:block lg:w-1/2'}`}>
+                                                                <div className="lg:sticky lg:top-0 lg:max-h-dvh lg:overflow-y-auto">
+                                                                    {orderSelected && <OrderInfo order={orderSelected}/>}
+                                                                </div>
                                                             </div> :
                                                             <MobileOrderInfo order={orderSelected}
                                                                              setOrder={handleState}/>


### PR DESCRIPTION
## Summary
- keep desktop order info panel stuck to the viewport while scrolling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68969c64d8f883339d382d7205386169