### PR TITLE
feat: show individual AI insight cards on dashboard

### DIFF
--- a/src/components/pages/dashboard-home/insights-card.tsx
+++ b/src/components/pages/dashboard-home/insights-card.tsx
@@ -1,55 +1,50 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Lightbulb, Info } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Lightbulb, Info, TrendingUp, Users, ChefHat } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { useDashboardHomeContext } from "@/context/dashboard-home-context"
+import type { PerformanceInsightResponse, OccupancyInsightResponse, ItemsInsightResponse } from "@/types/insights"
 
-export default function InsightsCard() {
-    const { insights } = useDashboardHomeContext()
+interface InsightsCardProps {
+    performance?: PerformanceInsightResponse
+    occupancy?: OccupancyInsightResponse
+    items?: ItemsInsightResponse
+}
+
+export default function InsightsCard({ performance, occupancy, items }: InsightsCardProps) {
+    const cards = [
+        { title: "Desempenho", insight: performance?.insight, icon: TrendingUp },
+        { title: "Ocupação", insight: occupancy?.insight, icon: Users },
+        { title: "Itens", insight: items?.insight, icon: ChefHat },
+    ]
 
     return (
-        <Card className="col-span-full">
-            <CardHeader>
-                <CardTitle className="flex items-center space-x-2">
-                    <Lightbulb className="h-5 w-5" />
-                    <span>Insights com IA</span>
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span className="cursor-default">
-                                <Info className="h-3.5 w-3.5 text-muted-foreground" />
-                            </span>
-                        </TooltipTrigger>
-                        <TooltipContent>Sugestões automatizadas baseadas nos seus dados</TooltipContent>
-                    </Tooltip>
-                </CardTitle>
-                <CardDescription>Sugestões automatizadas baseadas nos seus dados</CardDescription>
-            </CardHeader>
-            <CardContent>
-                <div className="grid gap-4 md:grid-cols-3">
-                    {insights.map((insight, index) => {
-                        const Icon = insight.icon
-                        const bgColor =
-                            insight.type === "positive"
-                                ? "bg-green-50 border-green-200"
-                                : insight.type === "warning"
-                                    ? "bg-yellow-50 border-yellow-200"
-                                    : "bg-blue-50 border-blue-200"
-                        const iconColor =
-                            insight.type === "positive"
-                                ? "text-green-600"
-                                : insight.type === "warning"
-                                    ? "text-yellow-600"
-                                    : "text-blue-600"
-                        return (
-                            <div key={`insight-${index}`} className={`rounded-lg p-2 border transition-all duration-300 hover:shadow-md ${bgColor}`}>
-                                <div className="flex items-start space-x-3">
-                                    <Icon className={`h-4 w-4 min-h-4 min-w-4 mt-0.5 ${iconColor}`} />
-                                    <p className="text-sm leading-relaxed">{insight.message}</p>
-                                </div>
-                            </div>
-                        )
-                    })}
-                </div>
-            </CardContent>
-        </Card>
+        <section className="space-y-4">
+            <div className="flex items-center space-x-2">
+                <Lightbulb className="h-5 w-5" />
+                <span className="text-lg font-semibold">Insights com IA</span>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span className="cursor-default">
+                            <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Sugestões automatizadas baseadas nos seus dados</TooltipContent>
+                </Tooltip>
+            </div>
+            <div className="grid gap-4 md:grid-cols-3">
+                {cards.map(({ title, insight, icon: Icon }, index) => (
+                    <Card key={`insight-${index}`}>
+                        <CardHeader>
+                            <CardTitle className="flex items-center space-x-2">
+                                <Icon className="h-4 w-4" />
+                                <span>{title}</span>
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-sm leading-relaxed">{insight || "Sem dados disponíveis."}</p>
+                        </CardContent>
+                    </Card>
+                ))}
+            </div>
+        </section>
     )
 }


### PR DESCRIPTION
## Summary
- replace full insights hook with dedicated performance, occupancy and items insight hooks
- render three AI insight cards for performance, occupancy and items data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896b5fe3a948333a2794ecaaff23b8f