### PR TITLE
fix: annotate dashboard insights card metrics type

### DIFF
--- a/src/components/pages/dashboard-home/insights-card.tsx
+++ b/src/components/pages/dashboard-home/insights-card.tsx
@@ -64,7 +64,7 @@ function InsightCardItem({ title, insight, icon: Icon, metrics }: InsightCardIte
 }
 
 export default function InsightsCard({ performance, occupancy, items }: InsightsCardProps) {
-    const cards = [
+    const cards: InsightCardItemProps[] = [
         {
             title: "Desempenho",
             insight: performance?.insight,


### PR DESCRIPTION
## Summary
- ensure insights card metrics are typed as InsightCardItemProps array

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 43 problems (26 errors, 17 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_6896d313a9188333b22025ff22683c43