### PR TITLE
feat(stock): add recipe cost breakdown

### DIFF
--- a/src/pages/dashboard/stock/components/recipe-card.tsx
+++ b/src/pages/dashboard/stock/components/recipe-card.tsx
@@ -10,9 +10,10 @@ interface RecipeCardProps {
     menuItems: Item[];
     onEdit: (recipe: Recipe) => void;
     onDelete: (id: string) => void;
+    onViewCost?: (recipe: Recipe) => void;
 }
 
-export function RecipeCard({recipe, menuItems, onEdit, onDelete}: RecipeCardProps) {
+export function RecipeCard({recipe, menuItems, onEdit, onDelete, onViewCost}: RecipeCardProps) {
     const item = menuItems.find(i => i._id === recipe.menuItemId);
     const dishName = item?.name || recipe.dishName;
     const profit = (item?.price ?? 0) - recipe.cost;
@@ -32,7 +33,12 @@ export function RecipeCard({recipe, menuItems, onEdit, onDelete}: RecipeCardProp
                 </div>
                 <div className="flex justify-between">
                     <span>Lucro:</span>
-                    <span className={profit < 0 ? "text-red-500" : undefined}>{formatCurrency(profit)}</span>
+                    <span
+                        className={`${profit < 0 ? "text-red-500" : ""} ${onViewCost ? "cursor-pointer underline-offset-4 hover:underline" : ""}`}
+                        onClick={() => onViewCost?.(recipe)}
+                    >
+                        {formatCurrency(profit)}
+                    </span>
                 </div>
             </CardContent>
             <CardFooter className="justify-end gap-2">

--- a/src/pages/dashboard/stock/components/recipe-cost-sheet.tsx
+++ b/src/pages/dashboard/stock/components/recipe-cost-sheet.tsx
@@ -1,0 +1,81 @@
+import {Sheet, SheetContent, SheetHeader, SheetTitle} from "@/components/ui/sheet";
+import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from "@/components/ui/table";
+import {useStockContext} from "@/context/stock-context";
+import type {Recipe} from "@/types/stock";
+import type {Item} from "@/types/item";
+import {formatCurrency} from "@/utils/format-currency";
+
+interface RecipeCostSheetProps {
+  recipe: Recipe | null;
+  menuItem?: Item;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function RecipeCostSheet({recipe, menuItem, open, onOpenChange}: RecipeCostSheetProps) {
+  const {stockItems} = useStockContext();
+
+  if (!recipe) return null;
+
+  const totalCost = recipe.cost;
+  const price = menuItem?.price ?? 0;
+  const profit = price - totalCost;
+
+  const ingredients = recipe.ingredients.map((ing) => {
+    const product = stockItems.find((item) => item._id === ing.productId);
+    const unitCost = product?.cost ?? 0;
+    const cost = unitCost * ing.quantity;
+    return {
+      ...ing,
+      unitCost,
+      cost,
+    };
+  });
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Custo de {menuItem?.name || recipe.dishName}</SheetTitle>
+        </SheetHeader>
+        <div className="space-y-4 mt-4">
+          <div className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span>Preço</span>
+              <span>{formatCurrency(price)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Custo</span>
+              <span>{formatCurrency(totalCost)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span>Lucro</span>
+              <span className={profit < 0 ? "text-red-500" : undefined}>{formatCurrency(profit)}</span>
+            </div>
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Ingrediente</TableHead>
+                <TableHead>Qtd.</TableHead>
+                <TableHead>Custo</TableHead>
+                <TableHead>%</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {ingredients.map((ing) => (
+                <TableRow key={ing.productId}>
+                  <TableCell>{ing.productName}</TableCell>
+                  <TableCell>{`${ing.quantity} ${ing.unit}`}</TableCell>
+                  <TableCell>{formatCurrency(ing.cost)}</TableCell>
+                  <TableCell>{totalCost ? `${((ing.cost / totalCost) * 100).toFixed(1)}%` : "-"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+

--- a/src/pages/dashboard/stock/index.tsx
+++ b/src/pages/dashboard/stock/index.tsx
@@ -79,6 +79,7 @@ import {StockCard} from "./components/stock-card";
 import {RecipeCard} from "./components/recipe-card";
 import {MovementCard} from "./components/movement-card";
 import {StockSummary} from "./components/stock-summary";
+import {RecipeCostSheet} from "./components/recipe-cost-sheet";
 import {StockContext} from "@/context/stock-context";
 
 
@@ -180,11 +181,13 @@ export default function StockManagement() {
     const [isAddMovementOpen, setIsAddMovementOpen] = useState(false)
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
     const [isNewOrderOpen, setIsNewOrderOpen] = useState(false)
+    const [isRecipeCostOpen, setIsRecipeCostOpen] = useState(false)
     const [selectedSupplier, ] = useState<Supplier | null>(null)
 
     // Selected item states
     const [selectedItem, setSelectedItem] = useState<StockItem | null>(null)
     const [itemToDelete, setItemToDelete] = useState<StockItem | null>(null)
+    const [selectedRecipeCost, setSelectedRecipeCost] = useState<Recipe | null>(null)
 
     // Form states
     const [newProduct, setNewProduct] = useState({
@@ -745,6 +748,11 @@ export default function StockManagement() {
         )
     }
 
+    const handleViewRecipeCost = (recipe: Recipe) => {
+        setSelectedRecipeCost(recipe)
+        setIsRecipeCostOpen(true)
+    }
+
     const handleOpenEditRecipe = (recipe: Recipe) => {
         setEditRecipe({
             _id: recipe._id,
@@ -1132,7 +1140,12 @@ export default function StockManagement() {
                                                             <TableCell>{item?.name || recipe.dishName}</TableCell>
                                                             <TableCell>{recipe.servings}</TableCell>
                                                             <TableCell>{formatCurrency(recipe.cost)}</TableCell>
-                                                            <TableCell className={profit < 0 ? "text-red-500" : undefined}>{formatCurrency(profit)}</TableCell>
+                                                            <TableCell
+                                                                onClick={() => handleViewRecipeCost(recipe)}
+                                                                className={`${profit < 0 ? "text-red-500" : ""} cursor-pointer underline-offset-4 hover:underline`}
+                                                            >
+                                                                {formatCurrency(profit)}
+                                                            </TableCell>
                                                             <PermissionGate section={Sections.STOCK_RECIPES}
                                                                             operation="update" mode="hide">
                                                                 <TableCell className="text-right">
@@ -1171,6 +1184,7 @@ export default function StockManagement() {
                                             menuItems={menuItems}
                                             onEdit={handleOpenEditRecipe}
                                             onDelete={handleDeleteRecipe}
+                                            onViewCost={handleViewRecipeCost}
                                         />
                                     ))
                                 )}
@@ -1596,12 +1610,22 @@ export default function StockManagement() {
                         <Button onClick={() => setIsAddMovementOpen(false)} variant="outline" className="flex-1">Cancelar</Button>
                         <Button onClick={handleAddMovement} className="flex-1">Adicionar</Button>
                     </div>
-                </DialogContent>
-            </Dialog>
+        </DialogContent>
+    </Dialog>
 
-            {/* Edit Recipe Modal */}
-            <Dialog open={isEditRecipeOpen} onOpenChange={setIsEditRecipeOpen}>
-                <DialogContent className="sm:max-w-2xl">
+    <RecipeCostSheet
+        open={isRecipeCostOpen}
+        onOpenChange={(open) => {
+            setIsRecipeCostOpen(open)
+            if (!open) setSelectedRecipeCost(null)
+        }}
+        recipe={selectedRecipeCost}
+        menuItem={menuItems.find(i => i._id === selectedRecipeCost?.menuItemId)}
+    />
+
+    {/* Edit Recipe Modal */}
+    <Dialog open={isEditRecipeOpen} onOpenChange={setIsEditRecipeOpen}>
+        <DialogContent className="sm:max-w-2xl">
                     <DialogHeader>
                         <DialogTitle>Editar Receita</DialogTitle>
                         <DialogDescription>Altere os detalhes da receita.</DialogDescription>


### PR DESCRIPTION
## Summary
- add `RecipeCostSheet` to display menu item cost breakdown
- enable viewing breakdown by clicking recipe profit in table or card

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5cbe17c0833388aa7ce5ddd88ab7